### PR TITLE
chore(release): bump version to 0.0.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.49] - 2026-06-14
+
+Maintenance release. No functional or API changes since 0.0.48; this is a
+version bump for release hygiene.
+
+### Changed
+
+- Bumped package version to `0.0.49` across `pyproject.toml`,
+  `pain001/constants.py`, and `pain001/__init__.py`.
+
+### Security
+
+- No new advisories. The dependency set remains clean: `pip-audit` reports
+  zero known vulnerabilities across all locked packages, carrying forward the
+  remediations shipped in 0.0.48.
+
 ## [0.0.48] - 2026-06-12
 
 ### Highlights

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -17,7 +17,7 @@
 
 import logging
 
-__version__ = "0.0.48"
+__version__ = "0.0.49"
 
 # Library convention: emit nothing unless the host app configures
 # logging (PEP 282 / logging HOWTO).

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -22,7 +22,7 @@ from pathlib import Path
 BASE_DIR = Path(os.path.dirname(os.path.abspath(__file__))).resolve()
 
 # Shared metadata
-VERSION = "0.0.48"
+VERSION = "0.0.49"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 TEMPLATES_DIR = BASE_DIR / "templates"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pain001"
-version = "0.0.48"
+version = "0.0.49"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 license = "Apache-2.0"

--- a/releases/v0.0.49.md
+++ b/releases/v0.0.49.md
@@ -1,0 +1,34 @@
+# Pain001 Release v0.0.49
+
+**Release Date:** 2026-06-14
+**Tag:** v0.0.49
+**Python:** 3.10+
+**Status:** Stable
+
+## Executive Summary
+
+v0.0.49 is a maintenance release. There are **no functional or API changes
+since 0.0.48** — it is a version bump for release hygiene. All of the ISO 20022
+coverage, financial-correctness, packaging, and security work introduced in
+0.0.48 is carried forward unchanged.
+
+## Changes
+
+- Bumped the package version to `0.0.49` across `pyproject.toml`,
+  `pain001/constants.py`, and `pain001/__init__.py`.
+
+## Security
+
+- No new advisories. The dependency set remains clean: `pip-audit` reports zero
+  known vulnerabilities across all locked packages, carrying forward the
+  remediations shipped in 0.0.48.
+
+## Upgrade Notes
+
+Upgrading from 0.0.48 requires no code changes:
+
+```bash
+pip install --upgrade pain001
+```
+
+Python 3.10 or newer is required.


### PR DESCRIPTION
Maintenance release **v0.0.49**. Recreated branch supersedes the closed #163 (its head branch had been deleted, so GitHub could not reopen it).

## Summary

No functional or API changes since 0.0.48 — this is a version bump for release hygiene. All ISO 20022 coverage, financial-correctness, packaging, and security work from 0.0.48 carries forward unchanged.

## Changes

- Bump version to `0.0.49` across `pyproject.toml`, `pain001/constants.py`, `pain001/__init__.py`
- Add `[0.0.49]` CHANGELOG entry and `releases/v0.0.49.md` release note

## Security

- No new advisories. `pip-audit` reports zero known vulnerabilities across all locked packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)