### PR TITLE
refactor(api): migrate pydantic class Config to ConfigDict

### DIFF
--- a/pain001/api/models.py
+++ b/pain001/api/models.py
@@ -20,7 +20,13 @@
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+)
 
 
 class DataSourceType(str, Enum):
@@ -63,10 +69,7 @@ class ValidationRequest(BaseModel):  # pylint: disable=too-few-public-methods
         description="Table name for SQLite sources",
     )
 
-    class Config:
-        """Pydantic config."""
-
-        use_enum_values = False
+    model_config = ConfigDict(use_enum_values=False)
 
 
 class GenerateXMLRequest(BaseModel):
@@ -91,10 +94,7 @@ class GenerateXMLRequest(BaseModel):
         description="Table name for SQLite sources",
     )
 
-    class Config:
-        """Pydantic config."""
-
-        use_enum_values = False
+    model_config = ConfigDict(use_enum_values=False)
 
 
 class ValidationError(BaseModel):
@@ -168,10 +168,7 @@ class JobStatusResponse(BaseModel):
         default=0, description="Progress percentage (0-100)"
     )
 
-    class Config:
-        """Pydantic config."""
-
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class HealthResponse(BaseModel):


### PR DESCRIPTION
## Summary

Replaces the three deprecated class-based `Config` inner classes in `pain001/api/models.py` with pydantic v2's `model_config = ConfigDict(...)`.

## Why

- Removes `PydanticDeprecatedSince20` warnings emitted at import/runtime.
- Class-based `Config` is removed in pydantic v3 — this keeps the API models forward-compatible.

## Changes

- `ValidationRequest`, `GenerateXMLRequest` → `model_config = ConfigDict(use_enum_values=False)`
- `JobStatusResponse` → `model_config = ConfigDict(use_enum_values=True)`

No behavioural change — `use_enum_values` settings preserved per model.

## Verification

- `tests/test_api.py`: 34 passed, 4 skipped
- Full suite green (example-test failures locally were a venv install issue, not code; they pass with the package importable)
- `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)