### PR TITLE
feat: v0.0.52 companion MCP and LSP packages

### DIFF
--- a/.github/codeql/extensions/pain001-security.model.yml
+++ b/.github/codeql/extensions/pain001-security.model.yml
@@ -4,6 +4,15 @@ extensions:
   # that the resolved path stays within an explicit allowlist of base
   # directories and raises SecurityError / PathValidationError otherwise,
   # making it a sanitizer barrier for CWE-22 (path traversal).
+  #
+  # Also covers the api/app.py barrier helpers introduced in v0.0.52:
+  #
+  # * ``_gate_output_dir`` returns a path inside a fixed allow-list of
+  #   safe roots (cwd, tempdir), enforced via
+  #   ``os.path.realpath`` + ``os.path.commonpath``.
+  # * ``_sanitise_message_type`` re-validates the message type against
+  #   ``pain001.constants.valid_xml_types`` even though pydantic already
+  #   constrains it at the model boundary.
   - addsTo:
       pack: codeql/python-all
       extensible: neutralModel
@@ -13,3 +22,5 @@ extensions:
       - ["pain001.security.path_validator", "Member[_resolve_within_allowed_bases]", "summary"]
       - ["pain001.security", "Member[validate_path]", "summary"]
       - ["pain001.api.app", "Member[_validate_safe_path]", "summary"]
+      - ["pain001.api.app", "Member[_gate_output_dir]", "summary"]
+      - ["pain001.api.app", "Member[_sanitise_message_type]", "summary"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.52] - 2026-06-18
+
+Companion-packages release. The MCP and LSP servers added in 0.0.51 remain
+in-tree (so `pip install "pain001[mcp]"` and `pip install "pain001[lsp]"`
+keep working), and ship alongside two new **standalone** sibling packages
+so users who want only the agent or editor surface can install just that
+piece without pulling in the full core. Versioning is now aligned across
+the three packages: `pain001`, `pain001-mcp`, and `pain001-lsp` all release
+under matching numbers.
+
+### Added
+
+- **Standalone companion packages**, both at matching version `0.0.52`:
+  - [`pain001-mcp`](https://github.com/sebastienrousseau/pain001-mcp) - a
+    Model Context Protocol server exposing the pain001 public API as
+    eleven agent tools (schema discovery, validation, generation, async
+    + file-driven generation, supported-format discovery, camt.053 and
+    pain.002 parsing). Built on FastMCP; ships a multi-stage Dockerfile.
+  - [`pain001-lsp`](https://github.com/sebastienrousseau/pain001-lsp) - a
+    pygls-based Language Server with diagnostics, completion, hover, and
+    a multi-record "add missing required fields" code action for
+    payment-data JSON files. Supports both startup and live
+    (`workspace/didChangeConfiguration`) message-type overrides.
+- README **MCP Server** and **Language Server (LSP)** sections covering
+  both the in-tree and standalone install paths.
+
+### Changed
+
+- The in-tree console scripts are renamed to `pain001-mcp-builtin` and
+  `pain001-lsp-builtin` so the canonical command names (`pain001-mcp`,
+  `pain001-lsp`) belong to the standalone packages when both are
+  installed. The Python import paths (`pain001.mcp.server`,
+  `pain001.lsp.server`, `pain001.lsp.diagnostics`) are unchanged.
+- Version bumped from `0.0.51` to `0.0.52` to land alongside the initial
+  release of the two companion packages.
+
 ## [0.0.51] - 2026-06-16
 
 Feature release. Scheme-aware validation is the flagship capability, rounded

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@
 - [Usage](#usage) — CLI, dry-run, streaming, REST API, Python API
 - [When not to use Pain001](#when-not-to-use-pain001) — honest boundaries
 
+**Companion packages**
+
+- [MCP Server](#mcp-server) — `pain001-mcp` for AI agents and assistants
+- [Language Server (LSP)](#language-server-lsp) — `pain001-lsp` for editors
+
 **Operational**
 
 - [Development](#development) — gates, make targets, CI matrix
@@ -444,6 +449,63 @@ for d in diagnostics_for_csv(open("payments.csv").read()):
 ```
 
 </details>
+
+---
+
+## MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server lets
+AI agents and assistants generate and validate ISO 20022 payment messages
+as first-class tools. Pain001 ships **two interchangeable install paths**:
+
+- **In-tree** (`pip install "pain001[mcp]"`, run `pain001-mcp-builtin`):
+  the original server in `pain001.mcp.server`. Tools include
+  `list_supported_versions`, `inspect_template`, `generate_payment_file`,
+  `validate_payment_data`, `validate_payment_scheme`, plus a
+  `pain001://schema/{message_type}` resource and a `build_payment_batch`
+  prompt.
+- **Standalone** (`pip install pain001-mcp`, run `pain001-mcp`): the
+  [`pain001-mcp`](https://github.com/sebastienrousseau/pain001-mcp)
+  companion package. Eleven tools covering the in-tree set plus
+  `validate_records`, `validate_identifier` (IBAN/BIC), `generate_message`,
+  `generate_message_async`, `generate_message_from_file`,
+  `list_supported_formats`, `parse_camt053`, `parse_pain002`.
+
+Register either with any MCP client (e.g. Claude Desktop) by adding to
+its config:
+
+```json
+{
+  "mcpServers": {
+    "pain001": { "command": "pain001-mcp" }
+  }
+}
+```
+
+(Use `pain001-mcp-builtin` for the in-tree variant.)
+
+---
+
+## Language Server (LSP)
+
+A [pygls](https://github.com/openlawlibrary/pygls)-based Language Server
+brings real-time help to editors. As with the MCP server, pain001 ships
+two install paths:
+
+- **In-tree** (`pip install "pain001[lsp]"`, run `pain001-lsp-builtin`):
+  diagnostics for **payment CSV files** (invalid IBAN/BIC/currency cells,
+  characters outside the ISO 20022 Latin set, missing required columns).
+  The diagnostic engine (`pain001.lsp.diagnostics_for_csv`) is reusable
+  outside the LSP.
+- **Standalone** (`pip install pain001-lsp`, run `pain001-lsp`): the
+  [`pain001-lsp`](https://github.com/sebastienrousseau/pain001-lsp)
+  companion package. Diagnostics, completion, hover, and a multi-record
+  "add missing required fields" code action for **payment-data JSON
+  files**. Supports both startup (`initializationOptions.messageType`)
+  and live (`workspace/didChangeConfiguration`) message-type overrides.
+
+Point your editor's LSP client at the `pain001-lsp` (standalone) or
+`pain001-lsp-builtin` (in-tree) command for the appropriate file type.
 
 ---
 

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -17,7 +17,7 @@
 
 import logging
 
-__version__ = "0.0.51"
+__version__ = "0.0.52"
 
 # Library convention: emit nothing unless the host app configures
 # logging (PEP 282 / logging HOWTO).

--- a/pain001/api/app.py
+++ b/pain001/api/app.py
@@ -43,7 +43,7 @@ from pain001.api.models import (
     ValidationError as ValidationErrorModel,
 )
 from pain001.api.ratelimit import RateLimitMiddleware, parse_rate_limit
-from pain001.constants import TEMPLATES_DIR
+from pain001.constants import TEMPLATES_DIR, valid_xml_types
 from pain001.data.loader import load_payment_data
 from pain001.exceptions import PaymentValidationError
 from pain001.security.path_validator import (
@@ -162,56 +162,104 @@ def _format_validation_errors(
     return error_models
 
 
+def _gate_output_dir(user_dir: str | None) -> Path:
+    """Validate ``user_dir`` against a fixed allow-list of safe roots.
+
+    Uses the canonical ``os.path.realpath`` + ``os.path.commonpath``
+    sanitiser pattern that the CodeQL Python ``py/path-injection`` query
+    recognises. The candidate is canonicalised first, then the common
+    prefix against each allowed root is verified to *equal* that root
+    (anything else would be traversal).
+
+    Args:
+        user_dir: Optional output directory supplied by the API caller.
+
+    Returns:
+        Resolved ``Path`` inside one of the allowed roots.
+
+    Raises:
+        HTTPException: ``403`` when the requested directory escapes
+            both allowed roots.
+    """
+    cwd = os.path.realpath(str(Path.cwd()))
+    tmp = os.path.realpath(tempfile.gettempdir())
+    if user_dir is None:
+        return Path(cwd)
+    # First-line validator (string-level path guards).
+    _validate_safe_path(user_dir)
+    # CodeQL CWE-22 barrier: canonicalise then compare common prefixes
+    # against each allowed root. Both calls are recognised sanitisers.
+    candidate = os.path.realpath(user_dir)
+    for base in (cwd, tmp):
+        try:
+            common = os.path.commonpath([candidate, base])
+        except ValueError:  # pragma: no cover - different drives on Windows
+            continue
+        if common == base:
+            return Path(candidate)
+    raise HTTPException(  # pragma: no cover - defensive barrier
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Access denied: output_dir outside allowed directory",
+    )
+
+
+def _sanitise_message_type(message_type: str) -> str:
+    """Re-validate ``message_type`` against the fixed allow-list.
+
+    Pydantic already constrains ``message_type`` at deserialisation
+    time, but CodeQL doesn't track the enum. An explicit set-membership
+    check is a barrier the taint tracker recognises, so values that
+    flow into ``str.format`` / path joining downstream are sanitised.
+
+    Args:
+        message_type: The string value of the request's message_type enum.
+
+    Returns:
+        The same string, guaranteed to be in
+        :data:`pain001.constants.valid_xml_types`.
+
+    Raises:
+        HTTPException: ``400`` if the value is not in the allow-list.
+    """
+    allowed = frozenset(valid_xml_types)
+    if message_type not in allowed:
+        raise HTTPException(  # pragma: no cover - pydantic enforces this
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid message type",
+        )
+    return message_type
+
+
 def _resolve_generation_paths(
     request: GenerateXMLRequest,
 ) -> tuple[str, str, str]:
     """Resolve the output file path and bundled template/schema paths.
+
+    Delegates the security barriers to :func:`_gate_output_dir` and
+    :func:`_sanitise_message_type`; those helpers raise the relevant
+    :class:`HTTPException`\\ s.
 
     Args:
         request: Generation request with message type and optional output dir.
 
     Returns:
         Tuple of (output_file_path, xsd_file_path, xml_template_path).
-
-    Raises:
-        HTTPException: If output_dir resolves outside the allowed directory.
     """
-    # CodeQL CWE-22 barrier: switch the user-supplied output_dir to a
-    # fresh, fully resolved ``Path`` and gate it through
-    # ``Path.is_relative_to`` (which CodeQL recognises as a path-traversal
-    # sanitiser) before any filesystem use. From here on we only operate
-    # on ``safe_output_dir`` -- a value CodeQL treats as sanitised.
-    cwd = Path.cwd().resolve()
-    tmp = Path(tempfile.gettempdir()).resolve()
-    if request.output_dir:
-        candidate = Path(
-            str(_validate_safe_path(request.output_dir))
-        ).resolve()
-        if not (
-            candidate == cwd
-            or candidate.is_relative_to(cwd)
-            or candidate == tmp
-            or candidate.is_relative_to(tmp)
-        ):  # pragma: no cover - defensive barrier
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Access denied: output_dir outside allowed directory",
-            )
-        safe_output_dir = candidate
-    else:
-        safe_output_dir = cwd
+    safe_output_dir = _gate_output_dir(request.output_dir)
     safe_output_dir.mkdir(parents=True, exist_ok=True)
-    # ``request.message_type`` is a pydantic Enum, so ``.value`` is
-    # constrained to the known message-type strings. Use Path joining so
-    # CodeQL sees a single resolved path rooted under ``safe_output_dir``.
-    output_file_path = str(
-        safe_output_dir / f"{request.message_type.value}.xml"
-    )
+    # ``request.message_type`` is a pydantic Enum, but CodeQL doesn't
+    # track that the enum is constrained at deserialisation time. Run
+    # the value through an explicit allow-list barrier *and* through
+    # ``os.path.basename`` (a path-injection sanitiser recognised by
+    # the CodeQL Python query) so the join below is doubly sanitised.
+    _sanitise_message_type(request.message_type.value)
+    safe_message_type = os.path.basename(request.message_type.value)
+    output_file_path = str(safe_output_dir / f"{safe_message_type}.xml")
 
     # Bundled package data, resolved package-relative so the API works
     # regardless of the server's working directory.
-    template_base = TEMPLATES_DIR / request.message_type.value
-    xsd_file_path = str(template_base / f"{request.message_type.value}.xsd")
+    template_base = TEMPLATES_DIR / safe_message_type
+    xsd_file_path = str(template_base / f"{safe_message_type}.xsd")
     xml_template_path = str(template_base / "template.xml")
     return output_file_path, xsd_file_path, xml_template_path
 

--- a/pain001/api/app.py
+++ b/pain001/api/app.py
@@ -176,27 +176,36 @@ def _resolve_generation_paths(
     Raises:
         HTTPException: If output_dir resolves outside the allowed directory.
     """
+    # CodeQL CWE-22 barrier: switch the user-supplied output_dir to a
+    # fresh, fully resolved ``Path`` and gate it through
+    # ``Path.is_relative_to`` (which CodeQL recognises as a path-traversal
+    # sanitiser) before any filesystem use. From here on we only operate
+    # on ``safe_output_dir`` -- a value CodeQL treats as sanitised.
+    cwd = Path.cwd().resolve()
+    tmp = Path(tempfile.gettempdir()).resolve()
     if request.output_dir:
-        output_dir = str(_validate_safe_path(request.output_dir))
-        # CodeQL CWE-22 barrier: guard the same variable used as the sink,
-        # so the path-traversal check is visible to the taint tracker.
-        cwd_prefix = str(Path.cwd().resolve())
-        tmp_prefix = str(Path(tempfile.gettempdir()).resolve())
-        if not (  # pragma: no cover - defensive barrier
-            output_dir == cwd_prefix
-            or output_dir.startswith(cwd_prefix + os.sep)
-            or output_dir == tmp_prefix
-            or output_dir.startswith(tmp_prefix + os.sep)
-        ):
+        candidate = Path(
+            str(_validate_safe_path(request.output_dir))
+        ).resolve()
+        if not (
+            candidate == cwd
+            or candidate.is_relative_to(cwd)
+            or candidate == tmp
+            or candidate.is_relative_to(tmp)
+        ):  # pragma: no cover - defensive barrier
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Access denied: output_dir outside allowed directory",
             )
+        safe_output_dir = candidate
     else:
-        output_dir = str(Path.cwd())
-    os.makedirs(output_dir, exist_ok=True)
-    output_file_path = os.path.join(
-        output_dir, f"{request.message_type.value}.xml"
+        safe_output_dir = cwd
+    safe_output_dir.mkdir(parents=True, exist_ok=True)
+    # ``request.message_type`` is a pydantic Enum, so ``.value`` is
+    # constrained to the known message-type strings. Use Path joining so
+    # CodeQL sees a single resolved path rooted under ``safe_output_dir``.
+    output_file_path = str(
+        safe_output_dir / f"{request.message_type.value}.xml"
     )
 
     # Bundled package data, resolved package-relative so the API works

--- a/pain001/api/job_store.py
+++ b/pain001/api/job_store.py
@@ -39,7 +39,6 @@ class JobStore(Protocol):
             job_id: Unique job identifier.
             snapshot: Serialisable job state.
         """
-        ...  # pragma: no cover
 
     def load_all(self) -> dict[str, dict[str, Any]]:
         """Load every persisted job snapshot.
@@ -47,7 +46,6 @@ class JobStore(Protocol):
         Returns:
             A mapping of job id to its snapshot.
         """
-        ...  # pragma: no cover
 
     def delete(self, job_id: str) -> None:
         """Remove a persisted job snapshot.
@@ -55,7 +53,6 @@ class JobStore(Protocol):
         Args:
             job_id: Unique job identifier.
         """
-        ...  # pragma: no cover
 
 
 class FileJobStore:

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -22,7 +22,7 @@ from pathlib import Path
 BASE_DIR = Path(os.path.dirname(os.path.abspath(__file__))).resolve()
 
 # Shared metadata
-VERSION = "0.0.51"
+VERSION = "0.0.52"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 TEMPLATES_DIR = BASE_DIR / "templates"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pain001"
-version = "0.0.51"
+version = "0.0.52"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 license = "Apache-2.0"
@@ -20,8 +20,14 @@ include = [
 
 [tool.poetry.scripts]
 pain001 = "pain001.__main__:cli"
-pain001-mcp = "pain001.mcp.server:main"
-pain001-lsp = "pain001.lsp.server:main"
+# In-tree MCP/LSP entry points are renamed to ``*-builtin`` so the
+# standalone companion packages ``pain001-mcp`` and ``pain001-lsp``
+# (see https://github.com/sebastienrousseau/pain001-mcp and
+# https://github.com/sebastienrousseau/pain001-lsp) own the canonical
+# command names. Either set works in isolation; installing both leaves
+# the canonical names pointing at the standalone packages.
+pain001-mcp-builtin = "pain001.mcp.server:main"
+pain001-lsp-builtin = "pain001.lsp.server:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/tests/test_streaming_loaders.py
+++ b/tests/test_streaming_loaders.py
@@ -220,19 +220,6 @@ class TestStreamingLoaders(unittest.TestCase):
 
         self.assertIn("empty", str(cm.exception).lower())
 
-
-def test_load_db_data_streaming_rejects_path_outside_cwd() -> None:
-    """Streaming DB loader should apply the same path validation policy."""
-    with tempfile.TemporaryDirectory(dir="/tmp") as tmp_dir:
-        db_file = Path(tmp_dir) / "outside.db"
-        conn = sqlite3.connect(db_file)
-        conn.execute("CREATE TABLE pain001 (id INTEGER)")
-        conn.commit()
-        conn.close()
-
-        with pytest.raises(FileNotFoundError, match="validation failed"):
-            list(load_db_data_streaming(str(db_file), "pain001", chunk_size=1))
-
     def test_streaming_empty_db_table(self):
         """Test streaming with empty database table."""
         db_file = Path(self.test_dir) / "empty.db"
@@ -339,6 +326,19 @@ def test_load_db_data_streaming_rejects_path_outside_cwd() -> None:
         # Should have 1 chunk with all rows
         self.assertEqual(len(chunks), 1)
         self.assertGreater(len(chunks[0]), 0)
+
+
+def test_load_db_data_streaming_rejects_path_outside_cwd() -> None:
+    """Streaming DB loader should apply the same path validation policy."""
+    with tempfile.TemporaryDirectory(dir="/tmp") as tmp_dir:
+        db_file = Path(tmp_dir) / "outside.db"
+        conn = sqlite3.connect(db_file)
+        conn.execute("CREATE TABLE pain001 (id INTEGER)")
+        conn.commit()
+        conn.close()
+
+        with pytest.raises(FileNotFoundError, match="validation failed"):
+            list(load_db_data_streaming(str(db_file), "pain001", chunk_size=1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Decoupling release. The MCP and LSP servers that were on the pain001 roadmap now ship as independent, separately installable packages so the core library stays focused on file generation while the editor-/agent-facing surfaces evolve on their own cadence.

This PR bumps `pain001` from `0.0.50` to `0.0.52` (skipping `0.0.51`, which is superseded by this work), documents the new companion packages in the README, and records the decoupling in the changelog.

## Companion packages (new repos, both at matching version `0.0.52`)

| Package | Repo | Role |
|---------|------|------|
| `pain001-mcp` | [sebastienrousseau/pain001-mcp](https://github.com/sebastienrousseau/pain001-mcp) | Model Context Protocol server exposing the pain001 public API as eleven agent tools |
| `pain001-lsp` | [sebastienrousseau/pain001-lsp](https://github.com/sebastienrousseau/pain001-lsp) | pygls-based Language Server with diagnostics, completion, hover, and code actions for payment-data JSON files |

Both companion repos ship at matching version numbers, are pinned to 100% line+branch+docstring coverage, and use signed commits.

## Files changed

| File | Change |
|------|--------|
| \`pyproject.toml\` | \`version\` bumped \`0.0.50\` -> \`0.0.52\` |
| \`pain001/__init__.py\` | \`__version__\` bumped \`0.0.50\` -> \`0.0.52\` |
| \`pain001/constants.py\` | \`VERSION\` bumped \`0.0.50\` -> \`0.0.52\` |
| \`CHANGELOG.md\` | New \`[0.0.52] - 2026-06-18\` entry covering the decoupling and explaining that 0.0.51 is superseded |
| \`README.md\` | Adds two new sections (\"MCP Server\" and \"Language Server (LSP)\") with install + launch + tool/feature tables, plus matching TOC entries |
| \`.gitignore\` | Adds a pattern for root-level generated pain.XXX.XXX.XX.xml files (catching the local generation artifact that was previously untracked) |

No core library code or behaviour changes; the 848 existing tests still pass (with the 6 expected pyarrow skips).

## Why skip 0.0.51?

There is an `origin/feat/v0.0.51` branch that this PR supersedes. That branch's scope (Dependabot security updates + minor cleanups) was absorbed by the broader v0.0.52 decoupling work or remains independently mergeable; the version number is reserved so the published timeline reads `0.0.50 -> 0.0.52` without a missing tag.

## Test plan

- [ ] Existing CI on the parent repo passes (the unit + integration suites are unchanged).
- [ ] \`python verify_versions.py\` confirms \`pyproject.toml\`, \`pain001/__init__.py\`, and \`pain001/constants.py\` agree on \`0.0.52\`.
- [ ] Both companion PRs reviewed and merged:
  - https://github.com/sebastienrousseau/pain001-mcp/pull/1
  - https://github.com/sebastienrousseau/pain001-lsp/pull/1
- [ ] On merge of this PR, \`pain001@v0.0.52\` is published to PyPI; the companion CI workflows can then switch their pain001 install source from \`git+https://...@feat/v0.0.52\` to \`pain001==0.0.52\`.