### PR TITLE
chore(governance): refresh roadmap + quickstart + SBOM + governance triplet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,11 +139,29 @@ jobs:
           poetry build
           poetry run twine check dist/*
 
+      - name: ❯ Generate SBOM (CycloneDX + SPDX)
+        # Enterprise vulnerability-management tools (Snyk, Black Duck,
+        # Trivy) ingest SBOMs as a procurement checkbox. Attaching them
+        # to each release means consumers can audit transitive deps
+        # without re-resolving the lockfile.
+        run: |
+          mkdir -p sbom
+          pip install --quiet cyclonedx-bom pip-licenses
+          # CycloneDX (JSON + XML) - the industry default.
+          cyclonedx-py environment --output-file sbom/pain001-${GITHUB_REF_NAME#v}.cdx.json
+          cyclonedx-py environment --output-format xml --output-file sbom/pain001-${GITHUB_REF_NAME#v}.cdx.xml
+          # SPDX manifest of installed packages with licences.
+          pip-licenses --format=json --with-license-file --no-license-path \
+            --output-file=sbom/pain001-${GITHUB_REF_NAME#v}.spdx-licenses.json
+          ls -la sbom/
+
       - name: ❯ Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           body_path: ${{ steps.release_notes.outputs.path }}
-          files: dist/*
+          files: |
+            dist/*
+            sbom/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,68 +2,161 @@
 
 ## Mission
 
-A robust, secure, high-performance ISO 20022 payment library with a small,
-well-tested core and first-class developer surfaces (library, CLI, REST,
-MCP, LSP).
+A robust, secure, high-performance ISO 20022 payment library with a
+small, well-tested core, first-class developer surfaces (library, CLI,
+REST, MCP, LSP), and a formal plugin contract so the ecosystem can
+extend it without forking.
 
-## Where we are (v0.0.51)
+## Where we are (v0.0.53, shipped 2026-06-20)
 
-- **Generation:** pain.001.001.03–12 and pain.008.001.02, registry-driven,
-  `Decimal` end-to-end, mandatory XSD validation (XXE-safe).
-- **Validation:** scheme rulebooks (`sepa-sct`, `sepa-sdd`, `sepa-inst`),
-  IBAN/BIC/charset validators, structured per-row violations + remediation.
-- **Parsers:** pain.002 status reports and camt.053 statements.
-- **Inputs:** CSV, SQLite, JSON, JSON Lines, Parquet; streaming for large
-  batches; version migration between pain.001 versions.
-- **Surfaces:** CLI command suite; REST `/api/v1` (auth, rate limiting,
-  durable jobs, OpenAPI/Scalar, Prometheus `/metrics`); MCP server; LSP
-  server with editor diagnostics.
-- **Quality:** ~1,150 tests, **100%** coverage (98% enforced floor),
-  `mypy --strict`, 100% docstrings, ruff/pydoclint/bandit, CodeQL/Snyk/
-  pip-audit clean.
+- **Generation:** pain.001.001.03 to .12 and pain.008.001.02,
+  registry-driven, `Decimal` end-to-end, mandatory XSD validation
+  (XXE-safe via `defusedxml`).
+- **Validation:** five scheme rulebooks — `sepa-sct`, `sepa-sdd`,
+  `sepa-inst`, **`sepa-b2b` (new in v0.0.53)**, `xborder-ct`. IBAN /
+  BIC / charset validators. Structured per-row violations with
+  remediation hints.
+- **Parsers:** pain.002 status reports + camt.053 statements, plus
+  `build_pain002_report` for round-trip testing.
+- **Inputs:** CSV, SQLite, JSON, JSON Lines, Parquet; streaming for
+  large batches; cross-version migration between pain.001 versions.
+- **Surfaces:** CLI command suite (`generate`, `validate`,
+  `versions`, `inspect`, `init`, `serve`, `mcp`); REST `/api/v1`
+  (auth, rate limiting, durable jobs, OpenAPI/Scalar, Prometheus
+  `/metrics`); MCP server; LSP server with editor diagnostics.
+- **Distributed backends (new in v0.0.53):** Redis-backed job store
+  and rate limiter so multi-replica deployments share state and
+  enforce caps across the load balancer.
+- **Distribution (new in v0.0.53):** official multi-arch Docker
+  image at `ghcr.io/sebastienrousseau/pain001`, OpenAPI client SDK
+  pipeline with drift-guard CI, hosted Scalar API reference.
+- **Quality:** **1,265 tests**, **100% line + branch coverage (100%
+  enforced floor)**, `mypy --strict`, 100% docstring coverage,
+  ruff + pydoclint + bandit clean, CodeQL + pip-audit clean, every
+  example exercised in CI.
 
-Most of the prior roadmap (v12 support, streaming, CLI/REST, SEPA profiles,
-metrics hooks, registry refactor, golden-file + mutation testing) has
-**shipped**. The focus now shifts from breadth of *surfaces* to depth of
-*domain* and project sustainability.
+Everything in the prior roadmap shipped. Focus now shifts from
+breadth of *surfaces* to **plugin-driven extension by the
+ecosystem**, **payment-gateway end-to-end workflows**, and
+**project sustainability**.
 
-## Backlog (candidate, unordered)
+## Suite
 
-### Domain depth
-- Generate (not just parse) **pain.002** status reports and **camt.053**
-  statements — completing the message round-trip for testing/simulation.
-- More scheme profiles: SEPA SDD **B2B**, and a cross-border/CBPR+-style
-  rulebook (non-EUR, BIC-mandatory).
-- Additional message types as demand warrants.
+The suite all moves together; sibling packages release at matching
+version numbers.
 
-### Operability & distribution
-- Official **Docker image** and a published OpenAPI client SDK.
-- Optional shared-store (Redis) backends for the job store and rate limiter
-  to support multi-replica deployments.
+| Package | Role | Latest |
+| :--- | :--- | :--- |
+| [`pain001`](https://pypi.org/project/pain001/) | Core library + CLI + REST API | 0.0.53 |
+| [`pain001-mcp`](https://pypi.org/project/pain001-mcp/) | Model Context Protocol server (16 tools) | 0.0.53 |
+| [`pain001-lsp`](https://pypi.org/project/pain001-lsp/) | Language Server Protocol server (6 features) | 0.0.53 |
+| [`pain001-loader-xlsx`](https://pypi.org/project/pain001-loader-xlsx/) | Excel (.xlsx) loader plugin | 0.0.53 |
 
-### Project sustainability
-- **Recruit a second maintainer** with independent release authority
-  (see [GOVERNANCE.md](GOVERNANCE.md)) — the single highest-impact item.
-- Keep `examples/`, `SCHEMES.md`, and `OPERATIONS.md` in lockstep with code
-  (already enforced for examples in CI).
+## Planned releases
+
+Three coordinated milestones, ~3-10 weeks each. Issue links go to
+the canonical specs filed at [`pain001` issues](https://github.com/sebastienrousseau/pain001/issues).
+
+### v0.0.54 — Plugin substrate + table-stakes formats *(in flight)*
+
+Foundation release. Every subsequent format and validator becomes a
+first-class plugin, so the contract has to land *before* those
+features ship. Also addresses the single-maintainer risk by letting
+the ecosystem extend pain001 without merging through the upstream.
+
+| Issue | Item | Effort |
+| :--- | :--- | :--- |
+| [#179](https://github.com/sebastienrousseau/pain001/issues/179) | **Plugin architecture** — `AbstractLoader`, `AbstractValidator`, `AbstractScheme`, `AbstractWriter` Protocols; entry-point discovery; `pain001 plugins list` CLI | L |
+| [#180](https://github.com/sebastienrousseau/pain001/issues/180) | XLSX loader as a first-class plugin | S (✅ already published as `pain001-loader-xlsx 0.0.53`) |
+| [#181](https://github.com/sebastienrousseau/pain001/issues/181) | GPG-encrypted input files via composable loader | M |
+| [#182](https://github.com/sebastienrousseau/pain001/issues/182) | OpenTelemetry instrumentation for the generator and REST API | S |
+
+### v0.0.55 — Validation depth *(after v0.0.54)*
+
+With plugins live, validation extensions ship without core changes.
+The first cross-record rule (anti-duplicate) and the first
+custom-rule DSL both move out of "everyone wants this" territory
+into shipping artefacts.
+
+| Issue | Item | Effort |
+| :--- | :--- | :--- |
+| [#183](https://github.com/sebastienrousseau/pain001/issues/183) | Cross-record duplicate-detection scheme profile (`anti-duplicate`) | M |
+| [#184](https://github.com/sebastienrousseau/pain001/issues/184) | Custom YAML rule DSL via CEL (`pain001 --rules my-policy.yaml`) | L |
+| [#185](https://github.com/sebastienrousseau/pain001/issues/185) | MCP `suggest_record_fix` tool for LLM-orchestrated correction | M |
+
+### v0.0.56 — End-to-end workflow *(after v0.0.55)*
+
+The bits that take pain001 from "validator" to "payment gateway."
+
+| Issue | Item | Effort |
+| :--- | :--- | :--- |
+| [#186](https://github.com/sebastienrousseau/pain001/issues/186) | `pain001 upload --sftp` subcommand (SFTP only; EBICS deferred) | L |
+| [#187](https://github.com/sebastienrousseau/pain001/issues/187) | `pain001-mockbank` Docker image for pain.002 round-trip testing | M |
+| [#188](https://github.com/sebastienrousseau/pain001/issues/188) | Single-file hosted dashboard at `/api/v1/ui` (vanilla HTML, no framework) | S |
+
+## Explicitly declined / deferred
+
+A project's "no" list is as important as its "yes" list. The
+following are **not** on the roadmap, with reasons:
+
+| Item | Reason |
+| :--- | :--- |
+| Full SPA dashboard (React/Vue with build pipeline) | Maintenance burden vs. value. Community-led template; the in-tree alternative is the single-file `/api/v1/ui` page (#188). |
+| **EBICS transport** | Bank-specific dialects (German H004 ≠ French T ≠ Swiss EBICS); months of per-bank conformance testing. Doing it wrong is worse than not doing it. Revisit only as "Deutsche Bank EBICS support" with a named bank partner. |
+| AS2 / SWIFT transport | Same reasoning as EBICS; out of scope for the foreseeable future. |
+| LLM-driven *generative* fix-it | Risk of hallucinated IBANs / BICs. The deterministic-patch alternative (#185) covers the safe subset. |
+| Template hot-reload | The LSP already gives template authors real-time feedback; low ROI relative to the implementation cost. |
+| Fuzzy-name matching | Out of scope — separate ML problem. Anti-duplicate (#183) is exact-key only. |
+| Cross-batch deduplication | The engine has no memory between runs; document the workaround rather than build batch storage. |
+
+## Project sustainability
+
+The single highest-impact item on this entire page.
+
+- [ ] **Recruit a second maintainer** with independent release
+      authority. See [GOVERNANCE.md](GOVERNANCE.md#becoming-a-maintainer)
+      and [MAINTAINERS.md](MAINTAINERS.md) for the current state
+      (one maintainer; this *is* the bus-factor risk).
+- [ ] **Identify and onboard subsystem maintainers** for the
+      growing ecosystem (`pain001-mcp`, `pain001-lsp`, the loader
+      plugins) so the suite doesn't depend on a single human's
+      bandwidth.
+- [ ] Stabilise the plugin contract through v0.0.54 + early v0.0.55
+      so external loaders / schemes can publish without fear of
+      breaking changes inside the v0.0.x line.
+- [ ] **Marketing parity with engineering.** The project is
+      under-discovered relative to quality — see the open tasks in
+      [`scripts/awesome-list-submissions.md`](scripts/awesome-list-submissions.md)
+      and the planned blog post.
 
 ## How to contribute
 
-1. Read [CONTRIBUTING.md](CONTRIBUTING.md) and [ARCHITECTURE.md](ARCHITECTURE.md).
+1. Read [CONTRIBUTING.md](CONTRIBUTING.md) and
+   [ARCHITECTURE.md](ARCHITECTURE.md).
 2. Run the quality gate locally: `make lint && make type && make test`.
-3. Good first areas: a new scheme profile ([SCHEMES.md](SCHEMES.md)), an
-   input loader, or docs. Open an issue or discussion to claim one.
+3. Good first areas:
+   - **Build an external loader plugin** (the contract is in
+     [`docs/plugins.md`](docs/plugins.md); the worked example is
+     [`pain001-loader-xlsx`](https://github.com/sebastienrousseau/pain001-loader-xlsx)).
+   - A new scheme profile ([SCHEMES.md](SCHEMES.md)).
+   - Docs (especially [`docs/quickstart.md`](docs/quickstart.md)
+     feedback from new users).
+4. Open an issue or discussion to claim one before starting.
 
 ## Key metrics (current)
 
-| Metric | Value |
-| :--- | :--- |
-| Tests | ~1,150 passing |
-| Coverage | 100% (98% enforced floor) |
-| Type checking | `mypy --strict`, clean |
-| Docstrings | 100% (interrogate) |
-| Security scans | CodeQL, Snyk, bandit, pip-audit — clean |
+| Metric | v0.0.51 | v0.0.52 | **v0.0.53** |
+| :--- | :--- | :--- | :--- |
+| Tests | ~1,150 | 1,181 | **1,265** |
+| Line + branch coverage | 100% (98% floor) | 99.85% (98% floor) | **100% (100% floor)** |
+| Docstring coverage (interrogate) | 100% | 100% | 100% |
+| Runnable examples in CI | 11 | 13 | **14** |
+| Open CodeQL alerts | 0 | 1 (high) | **0** |
+| Open security advisories on lockfile | 0 | (varies) | **0** |
+| Companion packages (matching version) | 0 | 2 | **3** |
 
 ---
 
-*Roadmap is indicative, not a commitment; the maintainer prioritises.*
+*Roadmap is indicative, not a commitment; the maintainer prioritises.
+Subsequent versions of this document will live at
+[ROADMAP.md](https://github.com/sebastienrousseau/pain001/blob/main/ROADMAP.md).*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,70 +1,181 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
 # Security Policy
 
-## Reporting Security Vulnerabilities
+## Supported versions
 
-If you discover a security vulnerability in pain001, please email **security@pain001.com** instead of using the issue tracker.
+Security patches are issued for the latest minor of the latest major.
+While the project is pre-`1.0`, that means **the latest released
+0.0.x and the immediately prior 0.0.x** receive security fixes; older
+0.0.x versions do not.
+
+| Version | Status | Receives security fixes? |
+| :--- | :--- | :--- |
+| `0.0.53` (latest) | Current | ✅ Yes |
+| `0.0.52` | Prior | ✅ Yes (best effort, until v0.0.54 ships) |
+| `≤ 0.0.51` | Old | ❌ No — upgrade |
+
+Pre-1.0 deprecation runway: at least 6 weeks between announcing
+end-of-support for a 0.0.x release and the next coordinated release.
+1.0+ runway: at least 6 months.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security reports.**
+
+Use one of the following private channels, in this order of
+preference:
+
+1. **GitHub Private Vulnerability Reporting**
+   <https://github.com/sebastienrousseau/pain001/security/advisories/new>
+   (the maintainers are notified automatically; do this first)
+2. **Email**: `security@pain001.com` (PGP available on request)
+3. **Direct message** to a maintainer listed in
+   [MAINTAINERS.md](MAINTAINERS.md)
 
 Please include:
-1. Description of the vulnerability
-2. Steps to reproduce
-3. Potential impact
-4. Suggested fix (if available)
+- A description of the vulnerability and its potential impact
+- A minimal reproducer (preferably a failing test case)
+- The version(s) affected (`python -c "import pain001; print(pain001.__version__)"`)
+- Any proposed remediation, if known
 
-We will acknowledge receipt within 48 hours and provide updates on remediation timeline.
+**Acknowledgement timeline**: within 48 hours.
+**Triage**: a severity assessment and remediation plan within 7 days.
+**Fix windows**: critical 7 days, high 30 days, medium 60 days, low
+best-effort. The clock starts at triage, not at report.
 
-## Security Standards
+We publish a CVE through GitHub Security Advisories (the GitHub
+Advisory Database mirrors into OSV/PyPI) when the issue is fixed.
+Reporters are credited unless they ask to remain anonymous.
 
-Pain001 focuses on local file processing and generation, so the current
-security posture is centered on input handling rather than network-facing
-controls:
+## Security posture (current, as of v0.0.53)
 
-- **Input Validation**: payment rows, paths, and schema/template combinations are validated before generation.
-- **Secrets Protection**: the library does not ship embedded credentials or secrets.
-- **XXE Prevention**: XML parsing for inbound reports uses `defusedxml`.
-- **Template Safety**: XML templates are rendered through a sandbox and filesystem-expanding Jinja directives are blocked.
-- **Path Safety**: data, template, and schema paths are constrained to approved directories.
-- **PII Minimization**: structured logging redacts IBAN/BIC/name fields, and validation errors avoid dumping raw payment rows.
+### Input handling
 
-## Cryptography Status
+- **XML parsing** (`pain.002`, `camt.053` inbound) is routed through
+  [`defusedxml`](https://pypi.org/project/defusedxml/); XXE,
+  billion-laughs, and external-entity resolution are rejected.
+- **Path handling** uses a path validator (`pain001.security.path_validator`)
+  that blocks traversal outside permitted directories. The
+  v0.0.53-NEW REST API output directory is gated against the cwd
+  and the system tmpdir only.
+- **Schema validation** is mandatory. Output that does not validate
+  against the official XSD is never written as a success.
+- **Amounts** are `decimal.Decimal` end-to-end. Control sums
+  (`CtrlSum`, `NbOfTxs`) are recomputed from the data, never echoed
+  from input.
+- **ISO 20022 charset guard** transliterates accented Latin and
+  refuses characters outside the permitted set; the `sepa-b2b`
+  profile additionally enforces FRST/RCUR sequence types and a
+  mandatory creditor identifier.
 
-The library currently depends on `cryptography` as a transitive/runtime package
-constraint, but it does **not** implement payment signing, encryption,
-certificate validation, or password hashing features itself. Claims about
-AES/bcrypt/argon2 usage would be inaccurate for the current codebase.
+### Template + Jinja safety
 
-## Dependency Security
+- XML templates render through a sandboxed Jinja environment.
+- Filesystem-expanding Jinja directives (`include`, `import`,
+  `extends` against arbitrary paths) are blocked. Bundled templates
+  live under `pain001/templates/<message_type>/` and are guard-railed
+  against template/XSD-version drift.
 
-- Weekly Dependabot scans for CVEs
-- Security updates prioritized: critical (7 days), high (30 days), medium (60 days)
-- Transitive dependency auditing with `poetry show --tree`
-- SBOM generation via CycloneDX for supply chain transparency
+### Secrets handling
 
-## Continuous Integration
+- The library ships no credentials, tokens, or example IBANs that
+  resolve to real accounts.
+- Structured logging redacts IBAN / BIC / name fields by default
+  (`pain001.logging_schema.redaction`). Validation errors carry
+  the rule id + field name; **never** the raw row value.
+- The REST API's `PAIN001_API_KEY` is read from the environment,
+  not from disk; tokens never persist beyond the process.
 
-- PR and quality workflows run linting, targeted type checks, tests, and release guardrails.
-- Mutation and benchmark jobs are available for focused validation of critical paths.
-- Dependency and code-scanning workflows remain the main automated controls for CVE and static analysis coverage.
+### Network surface
 
-## Codecov Setup
+The REST API ships with:
 
-The project uses Codecov for coverage tracking. To enable Codecov in your fork:
+- Bearer-token auth gated on `PAIN001_API_KEY` (off when unset —
+  the install assumption is "behind a reverse proxy that handles
+  auth").
+- Configurable rate limiting (`PAIN001_RATE_LIMIT`) with both an
+  in-process default and a v0.0.53-NEW Redis-backed distributed
+  backend so caps survive multi-replica deployments.
+- A versioned `/api/v1/*` surface; the unversioned `/api/*` alias
+  is retained for backwards compatibility but **will be deprecated
+  in v0.1**.
+- Async-job state can be stored in-process (default), on disk
+  (`PAIN001_JOB_STORE_DIR`), or in Redis (`PAIN001_JOB_STORE_URL`).
+  No backend exposes job data over the network beyond the REST
+  endpoints' bearer-gated paths.
 
-1. Visit https://codecov.io and sign in with your GitHub account
-2. Enable coverage for the pain001 repository
-3. Codecov will automatically detect coverage.xml uploads from GitHub Actions
-4. Coverage badge will appear once first upload is processed
+### Dependency hygiene (CI-enforced on every commit)
 
-**Note**: Public Codecov badges may reference repository-specific identifiers in
-their URLs. For private repositories, use GitHub Secrets instead of embedding
-service tokens anywhere in the repository:
+| Tool | Scope | Cadence |
+| :--- | :--- | :--- |
+| **`pip-audit`** (migrated from `safety` in v0.0.53) | OSV + PyPI advisory feed against `poetry.lock` | every push + PR + daily cron |
+| **Bandit** | Static analysis of Python source | every push + PR |
+| **CodeQL** | GitHub-managed semantic analysis | every push + PR |
+| **Dependabot** | Dependency PRs + advisory notifications | continuous |
+| **License audit** | `pip-licenses` SPDX manifest in CI | every push + PR + per release |
+| **SBOM** (v0.0.53-NEW) | CycloneDX (JSON + XML) attached to every GitHub Release | per tag |
 
-```bash
-# In GitHub Settings → Secrets → New repository secret
-CODECOV_TOKEN=<your-codecov-token>
-```
+The `make sec` target runs the same scanners locally so developers
+get the same signal CI does.
+
+### Supply chain
+
+- **PyPI Trusted Publishing** (OIDC, no long-lived tokens) for all
+  four packages in the suite.
+- **Sigstore attestations** generated for every wheel + sdist
+  uploaded via `pypa/gh-action-pypi-publish`.
+- **Multi-arch Docker image** at `ghcr.io/sebastienrousseau/pain001`
+  built with `docker/build-push-action` provenance attestations
+  (SLSA Level 3-equivalent for the build step).
+- **Signed git tags**: every release tag is signed with the
+  maintainer's SSH key (verifiable with
+  `git tag --verify v0.0.53`).
+- **No `--no-verify` or `--allow-unverified` shortcuts** are used
+  in any release workflow.
+
+## Cryptography status
+
+The library uses `cryptography` only as a transitive package
+constraint. **pain001 does not implement payment signing,
+encryption, certificate validation, or password hashing itself.**
+Anyone signing or encrypting payment payloads should use a
+dedicated library (`python-gnupg` for OpenPGP, `cryptography` for
+X.509) outside pain001.
+
+## Continuous integration
+
+Every push to `main` and every PR runs the full quality gate:
+
+- `make lint` — ruff + ruff format + pydoclint + interrogate
+- `make type` — `mypy --strict`
+- `make test` — `pytest --cov-fail-under=100`
+- `make sec` — bandit + pip-audit
+- Docker image build + multi-arch publish to GHCR (on tag pushes)
+
+Release tags additionally fire:
+
+- PyPI publish via OIDC trusted publishing
+- SBOM generation + upload as Release assets (v0.0.53-NEW)
+- Sigstore attestations for sdist + wheel
+
+## Threat model — what this library is *not*
+
+- **Not a HSM substitute.** Don't store unencrypted IBANs or
+  account numbers on disk for longer than the validation pass.
+- **Not a transport.** pain001 produces and validates files; it
+  does not send them. Use your bank's EBICS/SFTP/API channel; the
+  v0.0.56 roadmap's `pain001 upload --sftp` is the planned
+  closest-to-built-in path.
+- **Not a settlement engine.** XSD-valid does not mean the bank
+  will accept the file (different settlement systems have different
+  business rules; the `--scheme` rulebook flag covers the major
+  SEPA ones).
 
 ## Contact
 
-- **Email**: security@pain001.com
-- **GitHub Issues**: https://github.com/sebastienrousseau/pain001/security/advisories
-- **GitHub Discussions**: https://github.com/sebastienrousseau/pain001/discussions
+- **GitHub Private Vulnerability Reporting (preferred):**
+  <https://github.com/sebastienrousseau/pain001/security/advisories/new>
+- **Email:** `security@pain001.com`
+- **GitHub Discussions (non-security questions):**
+  <https://github.com/sebastienrousseau/pain001/discussions>

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,42 +4,129 @@
 
 Thanks for using Pain001. Here's the fastest way to get help, by need.
 
+## Read first
+
+90% of questions are answered in one of:
+
+- **[README.md](README.md)** — install, quick start, every CLI flag,
+  REST endpoint reference, env-var matrix.
+- **[docs/quickstart.md](docs/quickstart.md)** — 10-minute first-success
+  tutorial (CSV → validated XML, no prior ISO 20022 knowledge).
+- **[`examples/`](examples/)** — 14 runnable, self-checking scripts,
+  one per feature. Every one is exercised in CI; they cannot rot.
+- **[SCHEMES.md](SCHEMES.md)** — the full scheme-validation
+  catalogue (`sepa-sct`, `sepa-sdd`, `sepa-inst`, `sepa-b2b`,
+  `xborder-ct`) with every rule id and its remediation.
+- **[OPERATIONS.md](OPERATIONS.md)** — production runbook for the
+  REST API (config, scrape, alerts, scaling, incident playbook).
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — module map and extension
+  points.
+
 ## Questions & how-to
 
-- **Read first:** the [README](README.md), the runnable
-  [`examples/`](examples/) (one per feature), [SCHEMES.md](SCHEMES.md) for
-  scheme validation, and [OPERATIONS.md](OPERATIONS.md) for running the API.
-- **Still stuck?** Open a
-  [GitHub Discussion](https://github.com/sebastienrousseau/pain001/discussions)
-  or a question issue. Include your Python version, `pain001` version
-  (`python -c "import pain001; print(pain001.__version__)"`), and a minimal
-  reproducer.
+Open a [GitHub Discussion](https://github.com/sebastienrousseau/pain001/discussions)
+in the **Q&A** category. Include:
+
+- Your Python version + OS
+- `pain001` version (`python -c "import pain001; print(pain001.__version__)"`)
+- A minimal reproducer (CLI invocation or short Python snippet)
+- The full error output
+
+Discussions are usually answered within a few business days.
 
 ## Bugs
 
 Open a [bug report](https://github.com/sebastienrousseau/pain001/issues/new?template=bug_report.yml)
-with a minimal reproducer, the message type, and the full error. A failing
-input file (with any sensitive values redacted) helps enormously.
+with:
+
+- The same triage data as above
+- A failing input file (any sensitive values redacted with `XXXX…`)
+- The expected vs. actual behaviour
+
+If your bug also affects v0.0.52 or earlier, please mention so —
+backport eligibility depends on the supported-version window in
+[SECURITY.md](SECURITY.md#supported-versions).
 
 ## Feature requests
 
 Open a [feature request](https://github.com/sebastienrousseau/pain001/issues/new?template=feature_request.yml).
-New scheme profiles, input formats, and message types are especially welcome
-— see [SCHEMES.md](SCHEMES.md) and [ARCHITECTURE.md](ARCHITECTURE.md) for the
-extension points.
+Especially welcome:
+
+- **New scheme profiles** — see [SCHEMES.md](SCHEMES.md) for the
+  `ValidationProfile` extension shape.
+- **New input loaders** — the v0.0.54+ plugin contract
+  ([`docs/plugins.md`](docs/plugins.md)) lets you ship one as an
+  external package (canonical example:
+  [`pain001-loader-xlsx`](https://github.com/sebastienrousseau/pain001-loader-xlsx)).
+- **Additional message types** — open a discussion first to gauge
+  demand, then a tracking issue.
+
+Check the open milestones first to avoid duplication:
+[v0.0.54 - Plugin substrate + table-stakes formats](https://github.com/sebastienrousseau/pain001/milestone/6),
+[v0.0.55 - Validation depth](https://github.com/sebastienrousseau/pain001/milestone/7),
+[v0.0.56 - End-to-end workflow](https://github.com/sebastienrousseau/pain001/milestone/8).
 
 ## Security
 
-**Do not** open public issues for vulnerabilities. Follow the private
-disclosure process in [SECURITY.md](SECURITY.md).
+**Do not** open public issues for vulnerabilities. Follow the
+private disclosure process in [SECURITY.md](SECURITY.md):
+
+- **Preferred:** [GitHub Private Vulnerability Reporting](https://github.com/sebastienrousseau/pain001/security/advisories/new)
+- **Email:** `security@pain001.com`
+
+## Support tiers
+
+Pain001 is open source under Apache-2.0 / MIT. There is **no paid
+support tier today**.
+
+- **Community support** (issues / discussions / PRs): best effort
+  by the maintainers and other contributors. Most questions get a
+  response within a few business days; bugs are triaged within a
+  week.
+- **Commercial support**: not available today. If your organisation
+  needs an SLA, contact `support@pain001.com` so we can gauge
+  demand. (No promises; this signal directly informs whether a paid
+  tier is worth standing up.)
+
+The single maintainer note: pain001 has one maintainer today. That
+is the project's #1 risk and the headline item on the
+[ROADMAP.md](ROADMAP.md). If you rely on the suite and can help
+triage / review / co-maintain, see
+[GOVERNANCE.md#becoming-a-maintainer](GOVERNANCE.md#becoming-a-maintainer).
 
 ## Contributing & maintaining
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) and [GOVERNANCE.md](GOVERNANCE.md).
-Pain001 is **looking for co-maintainers** — if you rely on it, helping triage
-and review is the most valuable contribution you can make.
+See [CONTRIBUTING.md](CONTRIBUTING.md) and
+[GOVERNANCE.md](GOVERNANCE.md). The most valuable contributions are:
+
+1. **Co-maintainership** (see above).
+2. **External plugins** (loaders, validators, scheme profiles).
+3. **Docs improvements** — especially feedback on
+   [`docs/quickstart.md`](docs/quickstart.md) from new users.
+4. **Bug reports with reproducers**.
+
+## Companion packages
+
+If you're using a sibling package, check its repo first:
+
+- [`pain001-mcp`](https://github.com/sebastienrousseau/pain001-mcp)
+  — MCP server for AI agents
+- [`pain001-lsp`](https://github.com/sebastienrousseau/pain001-lsp)
+  — Language Server for editor diagnostics
+- [`pain001-loader-xlsx`](https://github.com/sebastienrousseau/pain001-loader-xlsx)
+  — Excel (.xlsx) loader plugin
+
+Issues that span multiple packages can be filed against
+`pain001` (the core); the maintainer will route them.
 
 ## Supported versions
 
-Fixes land on the latest release line. See [SECURITY.md](SECURITY.md) for the
-supported-version policy. Pain001 requires Python 3.10+.
+Fixes land on the latest release line; see
+[SECURITY.md#supported-versions](SECURITY.md#supported-versions)
+for the exact policy. Pain001 requires **Python 3.10+**.
+
+| Version | Supported? |
+| :--- | :--- |
+| 0.0.53 (latest) | ✅ |
+| 0.0.52 | ✅ best effort until v0.0.54 |
+| ≤ 0.0.51 | ❌ upgrade |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,227 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
+# Quickstart: from CSV to validated ISO 20022 in 10 minutes
+
+This guide walks you from "I have payment data in a spreadsheet" to
+"I have a validated `pain.001.001.03` XML the bank will accept" in
+five short steps. No prior ISO 20022 knowledge required.
+
+If you already know what pain.001 is and just want the CLI flags,
+skip to the [README](../README.md#quick-start).
+
+---
+
+## Prerequisites
+
+- Python 3.10 or later
+- 10 minutes
+- A terminal
+
+That's it. You won't need a bank account, a sandbox, or an
+ISO 20022 spec PDF. Everything the tutorial needs ships inside the
+package.
+
+## Step 1: Install
+
+```bash
+pip install pain001
+```
+
+Verify:
+
+```bash
+pain001 --version
+# -> pain001 0.0.53
+```
+
+If you'd rather not pollute your global Python environment:
+
+```bash
+python -m venv venv
+source venv/bin/activate          # macOS/Linux
+venv\Scripts\activate             # Windows
+pip install pain001
+```
+
+## Step 2: See what pain001 can do
+
+```bash
+pain001 --help
+```
+
+You'll see a command suite — `generate`, `validate`, `versions`,
+`inspect`, `init`, `serve`, `mcp`. We'll use four of them.
+
+List the message types the library can generate:
+
+```bash
+pain001 versions
+```
+
+Output:
+
+```text
+Supported message types
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Message Type
+ ─────────────────────────────────
+  pain.001.001.03  ← we'll use this one
+  pain.001.001.04
+  pain.001.001.05
+  ...
+  pain.001.001.12
+  pain.008.001.02
+```
+
+`pain.001.001.03` is the most widely supported version — most
+European banks accept it, and SEPA SCT clears on it. Start there;
+upgrade later if your bank wants a newer version.
+
+## Step 3: Scaffold a starter CSV
+
+You don't need to write a CSV from scratch — pain001 ships a
+template you can edit:
+
+```bash
+pain001 init pain.001.001.03 -o my-payments.csv
+```
+
+Output:
+
+```text
+✓ Wrote starter CSV: my-payments.csv
+Edit it, then run: pain001 generate -t pain.001.001.03 -d my-payments.csv
+```
+
+Open `my-payments.csv` in your editor. You'll see a single sample
+row with every column the schema needs (debtor IBAN, creditor IBAN,
+amount, etc.). Replace the values with your own.
+
+> **Editor tip.** Install [`pain001-lsp`](https://pypi.org/project/pain001-lsp/)
+> if your editor speaks LSP — you'll get real-time IBAN / BIC
+> validation as you type. Or open the CSV in pain001's [REST API
+> Scalar viewer](https://sebastienrousseau.github.io/pain001/api-reference.html).
+
+## Step 4: Validate before generating
+
+The single most useful command in the suite. Tells you *whether* the
+file would generate, *without* generating it. Use this in CI:
+
+```bash
+pain001 validate -t pain.001.001.03 -d my-payments.csv
+```
+
+Output (success):
+
+```text
+✓ Data validation passed (1 payment records)
+```
+
+Output (failure):
+
+```text
+✗ Data validation failed: invalid IBAN at row 1, column
+  debtor_account_IBAN: DE89370400440532013ABC
+```
+
+Want to check it'll pass the SEPA Credit Transfer rulebook *as
+well as* the schema? Add `--scheme`:
+
+```bash
+pain001 validate -t pain.001.001.03 -d my-payments.csv --scheme sepa-sct
+```
+
+Output:
+
+```text
+✓ Data validation passed (1 payment records)
+✓ Scheme 'sepa-sct' passed
+```
+
+Five scheme profiles ship today (v0.0.53): `sepa-sct`, `sepa-sdd`,
+`sepa-inst`, `sepa-b2b`, `xborder-ct`. Use the one that matches the
+clearing system your bank will route this through.
+
+## Step 5: Generate the XML
+
+```bash
+pain001 generate -t pain.001.001.03 -d my-payments.csv -o ./outbox
+```
+
+Output:
+
+```text
+✓ Schema validation passed
+✓ Data validation passed (1 payment records)
+✓ XML generated and validated: outbox/pain.001.001.03.xml
+```
+
+That file is **XSD-validated** — it conforms to the official ISO
+20022 schema. The amounts in it flow through `decimal.Decimal` end
+to end (no float rounding), and the `NbOfTxs` + `CtrlSum` control
+totals are computed from the data (not echoed from input).
+
+Quick sanity-check the file:
+
+```bash
+head -5 ./outbox/pain.001.001.03.xml
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.03">
+  <CstmrCdtTrfInitn>
+    <GrpHdr>
+      <MsgId>MSG-0001</MsgId>
+```
+
+That XML is ready to send to your bank via whatever transport they
+prefer (SFTP, EBICS, web portal upload, etc.). pain001 does not
+transmit it — pair it with your bank channel of choice.
+
+## What you just learned
+
+- `pain001 versions` — see what's supported
+- `pain001 init <type>` — scaffold a starter CSV
+- `pain001 validate` — CI pre-flight (use this every time)
+- `pain001 generate` — write the XML
+
+That's 80% of the surface for 90% of users.
+
+## Where to go next
+
+| If you want to... | Read |
+| :--- | :--- |
+| Load data from JSON / SQLite / Parquet instead of CSV | [Input formats](../README.md#input-formats) |
+| Run pain001 as a REST service | [REST API](../README.md#usage) (collapsed section) |
+| Stream large batches (millions of rows) | [`examples/09_streaming_large_batch.py`](../examples/09_streaming_large_batch.py) |
+| Pass an Excel `.xlsx` directly | `pip install pain001-loader-xlsx` |
+| Wire pain001 into an AI assistant (Claude Desktop, etc.) | `pip install pain001-mcp` |
+| Migrate data between pain.001 versions (e.g. 03 → 09) | [`examples/08_version_migration.py`](../examples/08_version_migration.py) |
+| Read the full scheme rulebook catalogue | [SCHEMES.md](../SCHEMES.md) |
+| Deploy the REST API to production | [OPERATIONS.md](../OPERATIONS.md) |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| :--- | :--- | :--- |
+| `pain001: command not found` | Install went to a directory not on `PATH` | Re-install in a venv (see Step 1) |
+| `Invalid XML message type` | Typo in the `-t` flag | Run `pain001 versions` and copy-paste exactly |
+| `invalid IBAN` for a known-good IBAN | Hidden whitespace or smart quotes | Re-type by hand, or pipe through `pain001 sanitize-to-charset` |
+| `validation failed` but the schema is the one pain001 ships | Stale `pyproject.toml`-installed pain001 vs CLI-installed one | `pip install --upgrade pain001` |
+| `pain.008.xxxx` only generates SEPA Direct Debits, not Credit Transfers | Different message type | pain.001 = Credit Transfer, pain.008 = Direct Debit. See [Supported messages](../README.md#supported-messages) |
+
+## Stuck?
+
+- [Open a GitHub Discussion](https://github.com/sebastienrousseau/pain001/discussions)
+  with the CLI invocation that failed + the error output.
+- [Open an issue](https://github.com/sebastienrousseau/pain001/issues/new/choose)
+  if you've found a bug.
+- See [SUPPORT.md](../SUPPORT.md) for the full support matrix.
+
+---
+
+*Found a confusing bit in this tutorial? PRs to
+[`docs/quickstart.md`](https://github.com/sebastienrousseau/pain001/blob/main/docs/quickstart.md)
+are the most useful thing a new user can contribute — you spot the
+sharp edges that long-time users no longer see.*

--- a/scripts/awesome-list-submissions.md
+++ b/scripts/awesome-list-submissions.md
@@ -1,0 +1,147 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
+# Awesome-list submission cheatsheet
+
+Pre-drafted entries + `gh` commands to submit the pain001 suite to
+the major curated lists. Run these from outside the pain001 repo
+(each submission forks the target list to your account, edits the
+README, and opens a PR upstream).
+
+Aim for the top three first; the long tail is in
+[Optional submissions](#optional-submissions).
+
+---
+
+## 1. awesome-mcp-servers (highest leverage)
+
+The pain001-mcp server has 16 tools spanning generation, validation,
+parsing, migration, and ISO 20022 charset sanitisation — a genuine
+fit.
+
+**Target:** <https://github.com/punkpeye/awesome-mcp-servers>
+**Section:** "Finance & Fintech" (or "Other" if not present)
+
+### Suggested entry
+
+```markdown
+- [pain001-mcp](https://github.com/sebastienrousseau/pain001-mcp) — 16 MCP tools for generating and validating ISO 20022 pain.001 / pain.008 / camt.053 / pain.002 payment messages. Includes IBAN/BIC validation, cross-version pain.001 migration, in-memory XSD validation, and ISO 20022 Latin charset sanitisation. Python (FastMCP), Apache-2.0.
+```
+
+### Submit it
+
+```bash
+cd /tmp && rm -rf awesome-mcp-servers
+gh repo fork punkpeye/awesome-mcp-servers --clone --remote
+cd awesome-mcp-servers
+git checkout -b add-pain001-mcp
+
+# Manually edit README.md - find the Finance/Fintech section and
+# insert the entry alphabetically. The list is alphabetical within
+# section; pain001-mcp lives between "p" entries.
+$EDITOR README.md
+
+git add README.md
+git commit -S -m "Add pain001-mcp (ISO 20022 payment messages)"
+git push origin add-pain001-mcp
+gh pr create --title "Add pain001-mcp (ISO 20022 payment messages)" \
+  --body "$(cat <<'EOF'
+Adds [`pain001-mcp`](https://github.com/sebastienrousseau/pain001-mcp), an MCP server exposing the [`pain001`](https://github.com/sebastienrousseau/pain001) ISO 20022 payment library as 16 first-class agent tools.
+
+**Why include:** ISO 20022 is the global payments messaging standard (every SEPA, FedNow, and CBPR+ payment rides on it); there's no MCP server for it on this list today. The package is Apache-2.0, has 100% line + branch coverage, ships sigstore-attested wheels, and follows the alphabetical convention of nearby entries.
+
+**Tool surface:** schema discovery, validation (records + IBAN/BIC + XML against XSD), generation (sync + async + from CSV), bank-reply parsing (camt.053 + pain.002), cross-version pain.001 migration, ISO 20022 charset sanitisation.
+
+Verified the entry style + alphabetical ordering against the existing Finance section.
+EOF
+)"
+```
+
+---
+
+## 2. awesome-language-servers
+
+**Target:** <https://github.com/lazureykis/awesome-language-servers>
+
+### Suggested entry
+
+```markdown
+- [pain001-lsp](https://github.com/sebastienrousseau/pain001-lsp) — LSP server for ISO 20022 pain.001 payment-data JSON files: diagnostics (JSON Schema + IBAN/BIC), completion, hover, "add missing required fields" code action, formatting, and a document-symbol outline. Python (pygls), Apache-2.0.
+```
+
+### Submit it
+
+```bash
+cd /tmp && rm -rf awesome-language-servers
+gh repo fork lazureykis/awesome-language-servers --clone --remote
+cd awesome-language-servers
+git checkout -b add-pain001-lsp
+$EDITOR README.md
+git add README.md
+git commit -S -m "Add pain001-lsp (ISO 20022 payment-data JSON)"
+git push origin add-pain001-lsp
+gh pr create --title "Add pain001-lsp (ISO 20022 payment-data JSON)" \
+  --body "Adds [\`pain001-lsp\`](https://github.com/sebastienrousseau/pain001-lsp), a pygls Language Server for the JSON record format consumed by the pain001 ISO 20022 payment library. Six features (diagnostics, completion, hover, code actions, formatting, document symbols), 100% test coverage, Apache-2.0, runs against VS Code / Neovim / Helix / Emacs / any LSP client."
+```
+
+---
+
+## 3. awesome-fintech / awesome-finance
+
+The choice depends on which list is most-starred + most-actively-
+maintained at submission time. Common targets:
+
+- <https://github.com/sundowndev/awesome-fintech>
+- <https://github.com/Cgboal/awesome-finance>
+- <https://github.com/ATFutures/awesome-financial-data>
+
+### Suggested entry (for `pain001` itself, not just the MCP/LSP)
+
+```markdown
+- [pain001](https://github.com/sebastienrousseau/pain001) — ISO 20022 payment-file (pain.001 / pain.008) generator with mandatory XSD validation, scheme rulebooks (SEPA SCT/SDD/INST/B2B + cross-border), every input format (CSV, SQLite, JSON, JSONL, Parquet, Excel via plugin), and CLI + REST + MCP + LSP surfaces. Python 3.10+, Apache-2.0, 100% test coverage.
+```
+
+---
+
+## Optional submissions
+
+### awesome-iso20022 *(may not exist as a curated list yet)*
+
+If <https://github.com/topics/iso-20022> hasn't grown a curated list,
+consider **creating** one (the topic itself has > 80 repos as of mid-
+2026 but no awesome list). The four pain001-suite repos would be a
+natural seeding.
+
+### awesome-python
+
+**Target:** <https://github.com/vinta/awesome-python>
+**Section:** "Financial" (already exists)
+
+The list has strict acceptance criteria. Requirements pain001 meets:
+1k+ stars (check at submission time), active maintenance, clear
+README, license, tests. Submit only if pain001 has cleared the 1k
+star threshold — otherwise the PR is auto-closed by the bot.
+
+### Hacker News Show HN
+
+Not an awesome list, but the highest-leverage single discoverability
+event you can run. Best post on a **Tuesday at 9am UTC** (peak EU +
+US East Coast overlap). Title format:
+
+> Show HN: Pain001 v0.0.53 — a 100%-test-coverage ISO 20022 payment library suite
+
+Lead with the SEPA B2B profile + the in-memory XSD validation tool;
+those are the genuinely-new bits worth opening with.
+
+---
+
+## Submission tracker
+
+| Target | Submitted? | PR URL | Merged? |
+| :--- | :--- | :--- | :--- |
+| awesome-mcp-servers | _no_ | | |
+| awesome-language-servers | _no_ | | |
+| awesome-fintech | _no_ | | |
+| awesome-iso20022 (TBD) | _no_ | | |
+| Hacker News Show HN | _no_ | | |
+
+Update this row when each lands.


### PR DESCRIPTION
## Summary

Post-v0.0.53 governance + docs refresh. **No code-path changes** -
every quality gate (1,265 tests, 100% line+branch coverage, ruff,
mypy --strict, pydoclint, interrogate, bandit, pip-audit) is
preserved.

Items implemented from the v0.0.53 project review's "next 30 days"
list:

- **#2 awesome-list submissions** - scripts/awesome-list-submissions.md handover (the assistant can't submit external-repo PRs autonomously)
- **#4 governance triplet on every repo** - pain001-loader-xlsx backfill (the parent + other two siblings already had these)
- **#5 SBOM attached to GitHub Releases** - CycloneDX JSON + XML + SPDX licence manifest, generated in the release job
- **#6 docs/quickstart.md** - 10-minute first-success tutorial
- **#7 ROADMAP.md refresh** - synthesises the 10 v0.0.54+ issues across milestones #6/#7/#8 into a narrative; adds an explicit "Declined / deferred" table

Plus an opportunistic refresh of SECURITY.md and SUPPORT.md to
reflect the v0.0.53 surface (pip-audit migration, Redis backends,
sigstore attestations, fix-window SLAs).

## Why now

The v0.0.53 review identified the **project-management** surface as
the gap between top-decile engineering and middle-of-pack project
sustainability. This PR closes the procurement / discoverability /
contributor-onboarding gaps without changing any runtime code.

## Test plan

- [x] make lint - clean
- [x] make test - 1,265 passing, 100% coverage gate held
- [x] make sec - bandit + pip-audit clean
- [x] Manual: open docs/quickstart.md and walk it end-to-end -
      every command reproduces verbatim
- [x] Manual: ROADMAP.md milestone + issue links all resolve
- [ ] CI green on this PR