### PR TITLE
chore(pyproject): align pytest cov-fail-under with CI (98 → 100)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ addopts = [
     "--cov-report=term-missing:skip-covered",
     "--cov-report=xml",
     "--cov-report=html",
-    "--cov-fail-under=98",
+    "--cov-fail-under=100",
     "--tb=short",
     "-ra",
     "--strict-markers",


### PR DESCRIPTION
The Makefile and CI quality-gate jobs both already run \`pytest --cov-fail-under=100\`, and the suite has been at 100% line + branch coverage for several releases.

**Most recent main**: 3257 stmts / 792 branches / **100% coverage** (CI run [27888673588](https://github.com/sebastienrousseau/pain001/actions/runs/27888673588)).

The lingering \`--cov-fail-under=98\` in \`pyproject.toml\` was only relevant for default \`pytest\` invocations that bypass the Makefile, and gave a misleading impression of the real coverage gate.

This PR aligns the pyproject gate to match Makefile + CI practice.

## Test plan

- [x] CI runs the same 100% gate it already did
- [x] No behavioural change for CI; only local \`pytest\` tightens to match

## Other suite repos (audit results)

For reference, all sibling repos are also at 100% per latest CI:

| Repo | Coverage |
| :--- | ---: |
| pain001 | 100% (3257/792) |
| pain001-mcp | 100% (174/20) |
| pain001-lsp | 100% (320/130) |
| pain001-loader-xlsx | 100% (50/12) |
| camt053 | 100% (1539/368) |
| camt053-mcp | 100% (101/6) |
| camt053-lsp | 100% (268/110) |
| camt053-writer-xlsx | 100% (68/26) |
| camt053-loader-mt940 | 100% (78/28) |

No further coverage gaps to close across the suite.