### PR TITLE
fix(deps): bump soupsieve to 2.8.4 to clear security advisories

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3486,14 +3486,14 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.1"
+version = "2.8.4"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
 python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434"},
-    {file = "soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350"},
+    {file = "soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"},
+    {file = "soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"},
 ]
 
 [[package]]


### PR DESCRIPTION
Clears the two open Dependabot alerts on this repo.

## What
`soupsieve` (transitive via `beautifulsoup4`) was locked at **2.8.1**, in the vulnerable range (`<= 2.8.3`) for:
- Memory Exhaustion via large comma-separated selector lists
- ReDoS via the selector parser

Targeted `poetry update soupsieve` → **2.8.4** (first patched). Lock-only change (3 lines); no `pyproject.toml`, API, or version change.

## Verification
Full suite green: **1265 passed**, 9 skipped. Lock diff touches only soupsieve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)