### PR TITLE
fix(security): path-injection hardening + mcp>=1.28.1 (v0.0.55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.55] - 2026-07-18
+
+Security hardening for the async job API and a dependency bump. Closes the
+outstanding CodeQL path-injection findings on the job store and the API
+output-directory sink, and clears the `mcp` Dependabot advisory.
+
+### Security
+
+- **Job id path-traversal hardening (`pain001/api/job_store.py`, CWE-22):**
+  every identifier that becomes part of a filesystem path or Redis key is now
+  validated against a strict safe-token pattern
+  (`[A-Za-z0-9][A-Za-z0-9_-]{0,127}`) before use — rejecting path separators,
+  `..`, and leading dots. `FileJobStore._path` additionally enforces a
+  canonical `os.path.realpath` + `os.path.commonpath` + `startswith`
+  containment barrier so a resolved job file can never escape the store
+  directory, and `RedisJobStore._key` validates the id before namespacing it.
+- **API output-directory sink (`pain001/api/app.py`):** `_gate_output_dir`
+  now applies the `startswith` containment barrier on the canonicalised
+  candidate it returns, so the downstream `mkdir` sink clears the CodeQL
+  `py/path-injection` query natively rather than relying on the neutral model.
+
+### Changed
+
+- **`mcp` dependency raised to `>=1.28.1,<2`** (was `>=1.23,<2`) to clear the
+  Dependabot advisory affecting `mcp < 1.28.1`; `poetry.lock` now resolves
+  `mcp` 1.28.1.
+
+### Fixed
+
+- **`tests/test_sepa_b2b_profile.py`:** collapsed the duplicate
+  `import pain001` / `from pain001 import validate_scheme` pair into a single
+  `from pain001 import __version__, validate_scheme`, resolving the
+  `py/import-and-import-from` note.
+
 ## [0.0.54] - 2026-07-16
 
 LLM-ergonomic generate path. Driven by a real agent transcript in which

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ CI workflows:
 | `pr.yml` | Pull-request gate |
 | `docs.yml` | Build and deploy documentation |
 
-Current state (v0.0.54): **1,309 tests passing**, **100% line + branch
+Current state (v0.0.55): **1,324 tests passing**, **100% line + branch
 coverage** against a **100% enforced floor**, mypy `--strict` clean,
 100% docstring coverage (interrogate). Coverage excludes only
 entry-point guards and genuinely-defensive barriers via

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -17,7 +17,7 @@
 
 import logging
 
-__version__ = "0.0.54"
+__version__ = "0.0.55"
 
 # Library convention: emit nothing unless the host app configures
 # logging (PEP 282 / logging HOWTO).

--- a/pain001/api/app.py
+++ b/pain001/api/app.py
@@ -195,7 +195,15 @@ def _gate_output_dir(user_dir: str | None) -> Path:
             common = os.path.commonpath([candidate, base])
         except ValueError:  # pragma: no cover - different drives on Windows
             continue
-        if common == base:
+        # ``commonpath`` equality plus an explicit ``startswith`` on the
+        # canonicalised candidate are both barriers the CodeQL
+        # py/path-injection query recognises. Requiring them together — on
+        # the very value returned and later passed to ``mkdir`` — lets the
+        # taint tracker clear the sink natively, without relying on the
+        # neutral model in pain001-security.model.yml.
+        if common == base and (
+            candidate == base or candidate.startswith(base + os.sep)
+        ):
             return Path(candidate)
     raise HTTPException(  # pragma: no cover - defensive barrier
         status_code=status.HTTP_403_FORBIDDEN,

--- a/pain001/api/job_store.py
+++ b/pain001/api/job_store.py
@@ -24,8 +24,37 @@ job submitted before a deploy can still be polled afterwards.
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
+
+# A job id becomes part of a filesystem path (``FileJobStore``) and a Redis
+# key (``RedisJobStore``). Both are security-sensitive sinks: a value such
+# as ``../../etc/passwd`` would let a caller escape the store directory
+# (CWE-22, path traversal). Constrain ids to a conservative safe token —
+# no path separators, no ``..``, no leading dot — before they are ever used
+# to build a path or key.
+_SAFE_JOB_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,127}")
+
+
+def _validate_job_id(job_id: str) -> str:
+    """Return ``job_id`` unchanged iff it is a safe identifier token.
+
+    Args:
+        job_id: Candidate job identifier, possibly attacker-controlled
+            (it originates from an API route parameter).
+
+    Returns:
+        The validated identifier.
+
+    Raises:
+        ValueError: If ``job_id`` is not a safe token (contains a path
+            separator, ``..``, a leading dot, or any other disallowed
+            character).
+    """
+    if not isinstance(job_id, str) or _SAFE_JOB_ID.fullmatch(job_id) is None:
+        raise ValueError(f"Unsafe job id: {job_id!r}")
+    return job_id
 
 
 @runtime_checkable
@@ -70,13 +99,35 @@ class FileJobStore:
     def _path(self, job_id: str) -> Path:
         """Return the on-disk path for a job id.
 
+        ``job_id`` is validated as a safe token first, then the resolved
+        candidate is asserted to stay within ``self.directory`` using the
+        canonical ``os.path.realpath`` + ``os.path.commonpath`` containment
+        pattern that the CodeQL ``py/path-injection`` query recognises.
+
         Args:
             job_id: Unique job identifier.
 
         Returns:
             The JSON file path for the job.
+
+        Raises:
+            ValueError: If ``job_id`` is not a safe token or the resolved
+                path would escape ``self.directory``.
         """
-        return self.directory / f"{job_id}.json"
+        safe_id = _validate_job_id(job_id)
+        base = os.path.realpath(str(self.directory))
+        candidate = os.path.realpath(os.path.join(base, f"{safe_id}.json"))
+        # Defence-in-depth CWE-22 barrier. ``_validate_job_id`` already
+        # rejects separators and ``..``, so this can only trip if ``base``
+        # itself is adversarial; it is the realpath+commonpath+startswith
+        # sanitiser the CodeQL taint tracker links to the write sinks.
+        if os.path.commonpath(
+            [candidate, base]
+        ) != base or not candidate.startswith(
+            base + os.sep
+        ):  # pragma: no cover - _validate_job_id makes this unreachable
+            raise ValueError(f"Refusing unsafe job id path: {job_id!r}")
+        return Path(candidate)
 
     def save(self, job_id: str, snapshot: dict[str, Any]) -> None:
         """Atomically persist a job snapshot as JSON.
@@ -160,8 +211,20 @@ class RedisJobStore:
         self._namespace = namespace.rstrip(":")
 
     def _key(self, job_id: str) -> str:
-        """Return the namespaced Redis key for a job id."""
-        return f"{self._namespace}:{job_id}"
+        """Return the namespaced Redis key for a job id.
+
+        The id is validated as a safe token first (via
+        :func:`_validate_job_id`, which raises ``ValueError`` on an unsafe
+        token) so it cannot inject namespace separators or otherwise escape
+        its key space.
+
+        Args:
+            job_id: Unique job identifier.
+
+        Returns:
+            The namespaced Redis key.
+        """
+        return f"{self._namespace}:{_validate_job_id(job_id)}"
 
     def save(self, job_id: str, snapshot: dict[str, Any]) -> None:
         """Persist a single job snapshot.

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -22,7 +22,7 @@ from pathlib import Path
 BASE_DIR = Path(os.path.dirname(os.path.abspath(__file__))).resolve()
 
 # Shared metadata
-VERSION = "0.0.54"
+VERSION = "0.0.55"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 TEMPLATES_DIR = BASE_DIR / "templates"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -51,7 +51,7 @@ description = "Reusable constraint types to use with typing.Annotated"
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"api\" or extra == \"mcp\""
+markers = "extra == \"mcp\" or extra == \"api\""
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -68,7 +68,7 @@ files = [
     {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
     {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
 ]
-markers = {main = "extra == \"api\" or extra == \"mcp\""}
+markers = {main = "extra == \"mcp\" or extra == \"api\""}
 
 [package.dependencies]
 exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
@@ -358,7 +358,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "extra == \"mcp\" and platform_python_implementation != \"PyPy\"", dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" and extra == \"mcp\"", dev = "sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and platform_machine != \"ppc64le\" and platform_machine != \"s390x\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -524,7 +524,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "extra == \"api\" and sys_platform == \"win32\" or platform_system == \"Windows\"", docs = "sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" and extra == \"api\" or platform_system == \"Windows\"", docs = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -692,7 +692,7 @@ files = [
     {file = "cryptography-48.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a"},
     {file = "cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a"},
 ]
-markers = {main = "extra == \"mcp\"", dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\""}
+markers = {main = "extra == \"mcp\"", dev = "sys_platform == \"linux\" and platform_machine != \"ppc64le\" and platform_machine != \"s390x\""}
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
@@ -813,7 +813,7 @@ files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
     {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
 ]
-markers = {main = "(extra == \"api\" or extra == \"mcp\" or extra == \"lsp\") and python_version == \"3.10\"", dev = "python_version == \"3.10\""}
+markers = {main = "(extra == \"mcp\" or extra == \"api\" or extra == \"lsp\") and python_version == \"3.10\"", dev = "python_version == \"3.10\""}
 
 [package.dependencies]
 typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
@@ -1123,7 +1123,7 @@ files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
 ]
-markers = {main = "extra == \"api\" or extra == \"mcp\""}
+markers = {main = "extra == \"mcp\" or extra == \"api\""}
 
 [package.extras]
 all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
@@ -1278,7 +1278,7 @@ description = "Low-level, pure Python DBus protocol wrapper."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\""
+markers = "sys_platform == \"linux\" and platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
 files = [
     {file = "jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"},
     {file = "jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"},
@@ -1626,15 +1626,15 @@ files = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 description = "Model Context Protocol SDK"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"mcp\""
 files = [
-    {file = "mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5"},
-    {file = "mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef"},
+    {file = "mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df"},
+    {file = "mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683"},
 ]
 
 [package.dependencies]
@@ -1642,13 +1642,22 @@ anyio = ">=4.5"
 httpx = ">=0.27.1,<1.0.0"
 httpx-sse = ">=0.4"
 jsonschema = ">=4.20.0"
-pydantic = ">=2.11.0,<3.0.0"
+pydantic = [
+    {version = ">=2.11.0,<3.0.0", markers = "python_version < \"3.14\""},
+    {version = ">=2.12.0,<3.0.0", markers = "python_version >= \"3.14\""},
+]
 pydantic-settings = ">=2.5.2"
 pyjwt = {version = ">=2.10.1", extras = ["crypto"]}
 python-multipart = ">=0.0.9"
-pywin32 = {version = ">=310", markers = "sys_platform == \"win32\""}
+pywin32 = [
+    {version = ">=310", markers = "sys_platform == \"win32\" and python_version < \"3.14\""},
+    {version = ">=311", markers = "sys_platform == \"win32\" and python_version >= \"3.14\""},
+]
 sse-starlette = ">=1.6.1"
-starlette = ">=0.27"
+starlette = [
+    {version = ">=0.27", markers = "python_version < \"3.14\""},
+    {version = ">=0.48.0", markers = "python_version >= \"3.14\""},
+]
 typing-extensions = ">=4.9.0"
 typing-inspection = ">=0.4.1"
 uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
@@ -2558,7 +2567,7 @@ files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
 ]
-markers = {main = "extra == \"mcp\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\"", dev = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\" and extra == \"mcp\"", dev = "sys_platform == \"linux\" and platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\" and platform_machine != \"ppc64le\" and platform_machine != \"s390x\""}
 
 [[package]]
 name = "pydantic"
@@ -2567,7 +2576,7 @@ description = "Data validation using Python type hints"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"api\" or extra == \"mcp\""
+markers = "extra == \"mcp\" or extra == \"api\""
 files = [
     {file = "pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d"},
     {file = "pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"},
@@ -2590,7 +2599,7 @@ description = "Core functionality for Pydantic validation and serialization"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"api\" or extra == \"mcp\""
+markers = "extra == \"mcp\" or extra == \"api\""
 files = [
     {file = "pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146"},
     {file = "pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2"},
@@ -3043,7 +3052,7 @@ description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
 optional = false
 python-versions = ">=3.6"
 groups = ["dev"]
-markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" and platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
 files = [
     {file = "pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"},
     {file = "pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"},
@@ -3438,7 +3447,7 @@ description = "Python bindings to FreeDesktop.org Secret Service API"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
-markers = "platform_machine != \"ppc64le\" and platform_machine != \"s390x\" and sys_platform == \"linux\""
+markers = "sys_platform == \"linux\" and platform_machine != \"ppc64le\" and platform_machine != \"s390x\""
 files = [
     {file = "secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"},
     {file = "secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be"},
@@ -3744,7 +3753,7 @@ description = "The little ASGI library that shines."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"api\" or extra == \"mcp\""
+markers = "extra == \"mcp\" or extra == \"api\""
 files = [
     {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
     {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
@@ -3952,7 +3961,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {main = "python_version < \"3.13\" or extra == \"api\" or extra == \"mcp\" or extra == \"lsp\""}
+markers = {main = "extra == \"mcp\" or extra == \"api\" or extra == \"lsp\" or python_version < \"3.13\""}
 
 [[package]]
 name = "typing-inspection"
@@ -3961,7 +3970,7 @@ description = "Runtime typing introspection tools"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "extra == \"api\" or extra == \"mcp\""
+markers = "extra == \"mcp\" or extra == \"api\""
 files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
@@ -4007,7 +4016,7 @@ description = "The lightning-fast ASGI server."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"mcp\" and sys_platform != \"emscripten\" or extra == \"api\""
+markers = "(sys_platform != \"emscripten\" or extra == \"api\") and (extra == \"mcp\" or extra == \"api\")"
 files = [
     {file = "uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f"},
     {file = "uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3"},
@@ -4035,7 +4044,7 @@ description = "Fast implementation of asyncio event loop on top of libuv"
 optional = true
 python-versions = ">=3.8.1"
 groups = ["main"]
-markers = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\" and extra == \"api\""
+markers = "platform_python_implementation != \"PyPy\" and extra == \"api\" and sys_platform != \"win32\" and sys_platform != \"cygwin\""
 files = [
     {file = "uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c"},
     {file = "uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792"},
@@ -4366,4 +4375,4 @@ redis = ["redis"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "95d14d9ab424e4a7831c8ca54bea92f89e7cba8dd0ab84d0f6d3439b698c28b8"
+content-hash = "eb610a7f3d6208b9600d9e99004565debac588aa38077d7e2faa1d45bd2a9758"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pain001"
-version = "0.0.54"
+version = "0.0.55"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 license = "Apache-2.0"
@@ -43,7 +43,7 @@ jsonschema = ">=4.17,<5"
 fastapi = {version = ">=0.95", optional = true}
 uvicorn = {version = ">=0.20", extras = ["standard"], optional = true}
 pyarrow = {version = ">=23.0.1,<25.0.0", optional = true}
-mcp = {version = ">=1.23,<2", optional = true}
+mcp = {version = ">=1.28.1,<2", optional = true}
 pygls = {version = ">=1.3,<2", optional = true}
 redis = {version = ">=5,<7", optional = true}
 

--- a/releases/v0.0.55.md
+++ b/releases/v0.0.55.md
@@ -1,0 +1,49 @@
+# Pain001 Release v0.0.55
+
+**Release Date:** 2026-07-18
+**Tag:** v0.0.55
+**Python:** 3.10+
+**Status:** Stable
+
+## Executive Summary
+
+A **security-hardening release**. It closes every open code-scanning and
+Dependabot finding: three `py/path-injection` alerts in the REST API's job
+store, the `mkdir` sink in the generation path, an import-style note, and the
+`mcp < 1.28.1` advisory. No behavioural change to valid requests.
+
+## What's in v0.0.55 at a glance
+
+- **Path-injection hardening (`pain001/api/job_store.py`)**: job identifiers
+  now pass a strict token guard (`^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$`,
+  `fullmatch`, raising `ValueError`) **before** they are ever used to build a
+  filesystem path or a Redis key. `FileJobStore` additionally resolves the
+  candidate with `os.path.realpath` and enforces a
+  `commonpath == base` + `startswith(base + os.sep)` containment barrier — the
+  canonical CWE-22 sanitiser the CodeQL `py/path-injection` query recognises.
+  `job_id` originates from the `GET /api/status/{job_id}` route parameter, so
+  this is a real defence, not only a static-analysis nicety.
+- **Output-directory sink (`pain001/api/app.py`)**: the canonicalised path
+  returned by `_gate_output_dir` now carries the recognised
+  `startswith(base + os.sep)` containment check alongside the existing
+  `commonpath` equality, so the value flowing into `mkdir` clears the query
+  natively (no reliance on the CodeQL model pack).
+- **Import hygiene**: collapsed a duplicate `import pain001` /
+  `from pain001 import …` in the SEPA B2B profile test into a single import.
+- **Dependency**: `mcp` raised to `>=1.28.1,<2` (Dependabot HIGH); `poetry.lock`
+  resolves `mcp` 1.28.1. `pip-audit` reports no known vulnerabilities.
+
+## Quality
+
+- 1,324 tests passing, 100% line + branch coverage against a 100% enforced
+  floor.
+- mypy `--strict` clean, 100% docstring coverage (interrogate), bandit clean.
+- New regression tests cover the job-id guard (traversal / separators /
+  leading-dot / empty rejected; UUIDs and safe tokens accepted) for both the
+  file-backed and Redis-backed stores.
+
+## Upgrade notes
+
+No API or configuration changes. Callers that were (incorrectly) relying on
+job identifiers containing path separators will now receive a `ValueError`;
+use plain identifier tokens (UUIDs are ideal).

--- a/tests/test_api_portal.py
+++ b/tests/test_api_portal.py
@@ -13,6 +13,8 @@
 
 """Tests for the REST API portal: versioning, rate limiting, persistence."""
 
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -219,6 +221,52 @@ class TestFileJobStore:
         assert "x" not in store.load_all()
         # Deleting a missing job is a no-op.
         store.delete("missing")
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "../../etc/passwd",
+            "../secret",
+            "a/b",
+            "a\\b",
+            ".hidden",
+            "",
+            "foo/../bar",
+            "with space",
+            "sub/../../escape",
+        ],
+    )
+    def test_path_rejects_traversal_and_separators(
+        self, tmp_path, bad_id
+    ) -> None:
+        """Unsafe job ids are rejected before a path is ever built."""
+        store = FileJobStore(tmp_path)
+        with pytest.raises(ValueError, match="Unsafe job id"):
+            store.save(bad_id, {"job_id": bad_id})
+        with pytest.raises(ValueError, match="Unsafe job id"):
+            store.delete(bad_id)
+
+    @pytest.mark.parametrize(
+        "good_id",
+        [
+            "abc",
+            "abc-123",
+            "job_42",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "A",
+        ],
+    )
+    def test_path_accepts_valid_ids_and_stays_contained(
+        self, tmp_path, good_id
+    ) -> None:
+        """Valid ids round-trip and their file stays inside the store dir."""
+        store = FileJobStore(tmp_path)
+        resolved = store._path(good_id)
+        base = Path(tmp_path).resolve()
+        assert resolved.parent == base
+        assert resolved.name == f"{good_id}.json"
+        store.save(good_id, {"job_id": good_id, "status": "pending"})
+        assert store.load_all()[good_id]["status"] == "pending"
 
     def test_from_env_unset(self, monkeypatch) -> None:
         """No store is built when the env var is unset."""

--- a/tests/test_redis_job_store.py
+++ b/tests/test_redis_job_store.py
@@ -198,3 +198,28 @@ def test_redis_url_or_client_required():
     """Constructor rejects calls without either ``url`` or ``client``."""
     with pytest.raises(ValueError, match="url or a client"):
         RedisJobStore()
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    ["../../etc/passwd", "a:b", "a/b", ".hidden", "", "with space"],
+)
+def test_redis_key_rejects_unsafe_ids(fake_redis_client, bad_id):
+    """Unsafe job ids are rejected before a Redis key is built."""
+    store = RedisJobStore(client=fake_redis_client)
+    with pytest.raises(ValueError, match="Unsafe job id"):
+        store.save(bad_id, {"job_id": bad_id})
+    with pytest.raises(ValueError, match="Unsafe job id"):
+        store.delete(bad_id)
+
+
+@pytest.mark.parametrize(
+    "good_id",
+    ["abc", "abc-123", "job_42", "550e8400-e29b-41d4-a716-446655440000"],
+)
+def test_redis_key_accepts_valid_ids(fake_redis_client, good_id):
+    """Valid ids namespace cleanly and round-trip through the store."""
+    store = RedisJobStore(client=fake_redis_client, namespace="ns:jobs")
+    assert store._key(good_id) == f"ns:jobs:{good_id}"
+    store.save(good_id, {"job_id": good_id, "status": "pending"})
+    assert store.load_all()[good_id]["status"] == "pending"

--- a/tests/test_sepa_b2b_profile.py
+++ b/tests/test_sepa_b2b_profile.py
@@ -19,8 +19,7 @@ from pathlib import Path
 
 import pytest
 
-import pain001
-from pain001 import validate_scheme
+from pain001 import __version__, validate_scheme
 from pain001.api.metrics import render_prometheus
 from pain001.validation.schemes import (
     PROFILES,
@@ -147,7 +146,7 @@ def test_prometheus_metric_reflects_new_profile_count() -> None:
 
     Criterion 6 of issue #173 (the metric reflects the new count).
     """
-    metrics_text = render_prometheus(pain001.__version__)
+    metrics_text = render_prometheus(__version__)
     assert "pain001_scheme_profiles" in metrics_text
     # Find the metric value line.
     lines = [


### PR DESCRIPTION
Fixes all open code-scanning + Dependabot findings. **Security:** strict `job_id` token validation + realpath/commonpath/startswith containment in `job_store.py` (both FileJobStore and RedisJobStore) resolving the 3 `py/path-injection` alerts; native containment barrier on `_gate_output_dir`'s returned path (app.py:249). Import-style note in a test resolved. **Deps:** `mcp>=1.28.1` (Dependabot HIGH). Version 0.0.54→0.0.55. 1324 tests, 100% coverage, mypy strict, bandit, pip-audit all clean; regression tests added for the id guards.