### PR TITLE
Release v0.0.59 — supply-chain hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.59] - 2026-07-30
+
+A **supply-chain** release. No runtime behaviour change and no public
+API change; what changes is what can be proven about the artefacts.
+
+### Fixed
+
+- **The Docker image installed `fastapi` and `uvicorn` unpinned.**
+  `requirements.txt` is hash-pinned but covers only the base install, so
+  `pip install ".[api]"` resolved the web stack from PyPI at image build
+  time. New hash-pinned `.github/requirements/api.txt` (13 pins, 144
+  hashes) supplies them; the package is then installed with `--no-deps`
+  so pip never resolves a third-party version. Same change in the docs
+  and SDK workflows.
+- **Release provenance attested 2 of 5 artefacts.** The SLSA job hashed
+  only `dist/`, while the CycloneDX and SPDX SBOMs are written to
+  `sbom/`. All five assets are covered now, and this is the first
+  release where the fix actually runs — v0.0.58's SBOMs were attested
+  only by a manual backfill, which cannot carry the tag binding.
+- **The backfill workflow attested its own attestation**, listing
+  `multiple.intoto.jsonl` as a subject and then overwriting it.
+  `*.intoto.jsonl` is excluded before hashing; re-runs are idempotent.
+- **`preflight_release.py`** reported `HEAD matches origin/main` with no
+  explanation when run on an unpushed release commit; it now names the
+  unpushed commit count and the fix.
+
 ## [0.0.58] - 2026-07-29
 
 A **correctness** release. Two bundled schemas were hand-authored

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -17,7 +17,7 @@
 
 import logging
 
-__version__ = "0.0.58"
+__version__ = "0.0.59"
 
 # Library convention: emit nothing unless the host app configures
 # logging (PEP 282 / logging HOWTO).

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -22,7 +22,7 @@ from pathlib import Path
 BASE_DIR = Path(os.path.dirname(os.path.abspath(__file__))).resolve()
 
 # Shared metadata
-VERSION = "0.0.58"
+VERSION = "0.0.59"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 TEMPLATES_DIR = BASE_DIR / "templates"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pain001"
-version = "0.0.58"
+version = "0.0.59"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 license = "Apache-2.0"

--- a/releases/v0.0.59.md
+++ b/releases/v0.0.59.md
@@ -1,0 +1,67 @@
+# Pain001 Release v0.0.59
+
+**Release Date:** 2026-07-30
+**Tag:** v0.0.59
+**Python:** 3.10+
+**Status:** Stable
+
+## Executive Summary
+
+A **supply-chain release**. There is no runtime behaviour change and no
+public API change — `pip install --upgrade pain001` gets you identical
+software. What changes is what can be proven about it: every dependency
+of the published Docker image is now hash-pinned, and release provenance
+covers every artefact rather than two of them.
+
+Nothing here is urgent for a user of the library. It matters if you
+verify what you install, or if you consume the container image.
+
+## Fixed
+
+- **The Docker image installed `fastapi` and `uvicorn` unpinned.**
+  `requirements.txt` is hash-pinned but covers only the base install, so
+  `pip install ".[api]"` resolved the web stack from PyPI at image build
+  time — whatever versions happened to be current that day. A new
+  hash-pinned `.github/requirements/api.txt` (13 pins, 144 hashes) now
+  supplies those dependencies, and the package itself is installed with
+  `--no-deps`, so pip never resolves a third-party version. The same
+  change applies to the docs and SDK workflows.
+
+- **Release provenance attested two of five artefacts.** The SLSA
+  `provenance` job hashed only `dist/`, while the CycloneDX and SPDX
+  SBOMs are written to `sbom/`, so those three files shipped unattested
+  in v0.0.58. All five release assets are now covered. This is the first
+  release where that fix actually runs — v0.0.58's SBOMs were attested
+  only by a manual backfill, which cannot carry the tag binding.
+
+- **The backfill workflow attested its own attestation.** Re-attesting a
+  release downloaded every asset, including the existing
+  `multiple.intoto.jsonl`, listed it as a subject, and then overwrote
+  it — leaving an attestation whose own subject digest matched nothing.
+  `*.intoto.jsonl` is excluded before hashing, which also makes re-runs
+  idempotent.
+
+- **`preflight_release.py` failed opaquely** when run on an unpushed
+  release commit: `1 problem(s): HEAD matches origin/main` reads like
+  something is wrong with the release rather than an ordering mistake.
+  It now names the unpushed commit count and the fix.
+
+## Verifying this release
+
+```bash
+slsa-verifier verify-artifact pain001-0.0.59-py3-none-any.whl \
+  --provenance-path multiple.intoto.jsonl \
+  --source-uri github.com/sebastienrousseau/pain001
+```
+
+Unlike v0.0.59's predecessor, the same command now succeeds for the SBOM
+files as well, and the provenance binds to `refs/tags/v0.0.59` rather
+than to a branch.
+
+## Upgrading
+
+```bash
+pip install --upgrade pain001
+```
+
+No API changes, no configuration changes, no regeneration needed.


### PR DESCRIPTION
Version bump, CHANGELOG entry and release note for **v0.0.59**.

No runtime behaviour change and no public API change — `pip install --upgrade pain001` gets identical software. What changes is what can be *proven* about it.

## What's in it

| | |
|---|---|
| **Docker image dependencies** | `fastapi`/`uvicorn` were resolved unpinned at image build time. Now hash-pinned via `.github/requirements/api.txt` (13 pins, 144 hashes) + `--no-deps`. |
| **Release provenance** | Attested 2 of 5 assets; the CycloneDX/SPDX SBOMs live in `sbom/` and the job only hashed `dist/`. All five covered now. |
| **Backfill workflow** | Attested its own attestation — listed `multiple.intoto.jsonl` as a subject, then overwrote it. |
| **`preflight_release.py`** | Reported `HEAD matches origin/main` with no explanation; now names the unpushed commit count and the fix. |

## Why cut it now

This is the **first release where the provenance fix actually runs**. v0.0.58's SBOMs were attested only by a manual backfill, which cannot carry the tag binding — its provenance points at `refs/heads/main` rather than `refs/tags/v0.0.58`. v0.0.59 gets both properties from the pipeline.

It also ages one unsigned release out of the Scorecard `Signed-Releases` window (2/5 → 3/5).

## After merge

`make release-check FULL=1` on `main`, then the signed tag. The pre-flight already passes every content check on this branch — only "on main" and "HEAD matches origin/main" are outstanding, which is exactly what merging resolves.