### PR TITLE
Require Developer Certificate of Origin sign-off

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## What this changes
+
+<!-- What behaviour changes, and why. -->
+
+## How it was verified
+
+<!-- What you ran, and what you observed. "Tests pass" is weaker than
+     naming the test and the result it produced. -->
+
+## Checklist
+
+- [ ] Every commit is signed off (`git commit -s`) — see [DCO.txt](../DCO.txt)
+- [ ] Tests cover the change (coverage is gated at 100%)
+- [ ] Documentation updated if behaviour or interfaces changed

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,55 @@
+# Developer Certificate of Origin check.
+#
+# Every commit in a pull request must carry a `Signed-off-by:` trailer,
+# which is the contributor asserting they have the right to submit the
+# work under this project's licence (see DCO.txt). Add one with:
+#
+#     git commit -s
+#
+# To fix a branch that is missing them:
+#
+#     git rebase --signoff main && git push --force-with-lease
+name: 📝 DCO
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Signed-off-by on every commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # Need the PR's commits, not just the merge result.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check every commit for a Signed-off-by trailer
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          # Merge commits carry the trailers of their parents, not their
+          # own, so they are exempt — checking them would fail every
+          # branch that merged main.
+          for sha in $(git rev-list --no-merges "$BASE..$HEAD"); do
+            if ! git log -1 --format='%B' "$sha" | grep -qiE '^Signed-off-by: .+ <.+@.+>'; then
+              echo "::error::missing Signed-off-by: $sha $(git log -1 --format='%s' "$sha")"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo
+            echo "$missing commit(s) lack a Signed-off-by trailer."
+            echo "Sign your commits with 'git commit -s', or fix an existing"
+            echo "branch with: git rebase --signoff <base> && git push --force-with-lease"
+            echo "See DCO.txt for what you are certifying."
+            exit 1
+          fi
+          echo "All commits carry a Signed-off-by trailer."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,6 +370,44 @@ poetry run make check
 
 ---
 
+## ✍️ Developer Certificate of Origin (MANDATORY)
+
+Every commit must carry a `Signed-off-by` trailer. This is the
+[Developer Certificate of Origin](DCO.txt) — your assertion that you
+wrote the contribution, or otherwise have the right to submit it under
+this project's licence. It is a legal statement, not a formality.
+
+Add it automatically:
+
+```bash
+git commit -s -m "your message"
+```
+
+which appends:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+The name and email must be real and must match your commit author
+identity. Configure them once:
+
+```bash
+git config user.name "Your Name"
+git config user.email "your.email@example.com"
+```
+
+Forgot on a branch you have already written? Fix every commit at once:
+
+```bash
+git rebase --signoff main
+git push --force-with-lease
+```
+
+CI enforces this on every pull request (`.github/workflows/dco.yml`);
+a commit without a sign-off fails the check and names the commit.
+Merge commits are exempt, since they carry their parents' trailers.
+
 ## 📤 Commit Message Format (MANDATORY)
 
 ```

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
`dco` is one of two criteria holding OpenSSF Best Practices **silver** at 93%. It's the one that can actually be fixed — the other is `bus_factor`, which needs a second maintainer.

**Correcting something I said earlier:** I claimed silver would survive these as Unmet because they're SHOULD rather than MUST. That was wrong. The badge requires 100% of a level's criteria and counts Unmet as unsatisfied regardless of category.

## A real mechanism, not a claim

- **`DCO.txt`** — the standard Developer Certificate of Origin 1.1.
- **`.github/workflows/dco.yml`** — fails a PR if any non-merge commit lacks a `Signed-off-by:` trailer, naming each offending commit and printing the rebase command that fixes them.
- **`CONTRIBUTING.md`** — how to sign off, how to repair a branch, and what is actually being certified.
- **`.github/pull_request_template.md`** — checklist including sign-off.

Merge commits are exempt: they carry their parents' trailers, so checking them would fail every branch that merged `main`.

## Verified before committing

Tested against a scratch repository rather than assumed:

```
one signed + one unsigned commit  ->  missing=1, names the unsigned one
after `git rebase --signoff`      ->  missing=0
```

This PR's own commit is signed off, and this check now runs on it — so the PR is its own first test.

## What this does and doesn't get us

Silver moves from 93% to roughly 96%. It does **not** reach 100%, because `bus_factor` requires a second significant contributor. That is the same wall behind gold's `two_person_review` and OpenSSF Scorecard's `Code-Review 0` — a person, not a setting.