### PR TITLE
Make the dual licence true everywhere it is stated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ ENV PIP_NO_CACHE_DIR=1 \
 # present at build-time for ``pip install .`` to resolve the package
 # metadata.
 COPY pyproject.toml README.md ./
+# pyproject declares `license-files`, so these must exist in the build
+# context or poetry-core fails metadata generation with
+# "No files found for license file glob pattern 'LICENSE'".
+COPY LICENSE LICENSE-APACHE LICENSE-MIT ./
 COPY pain001 ./pain001
 COPY requirements.txt ./
 COPY .github/requirements/api.txt ./api-requirements.txt

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """The Python pain001 module."""
 

--- a/pain001/__main__.py
+++ b/pain001/__main__.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 # pylint: disable=duplicate-code
 
 """Module entry point for ``python -m pain001``."""

--- a/pain001/api/__init__.py
+++ b/pain001/api/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pain001 FastAPI REST API module."""
 

--- a/pain001/api/app.py
+++ b/pain001/api/app.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pain001 FastAPI application."""
 

--- a/pain001/api/job_manager.py
+++ b/pain001/api/job_manager.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Job management for async XML generation."""
 

--- a/pain001/api/job_store.py
+++ b/pain001/api/job_store.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pluggable persistence for async generation jobs.
 

--- a/pain001/api/metrics.py
+++ b/pain001/api/metrics.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Dependency-free Prometheus metrics for the Pain001 REST API.
 

--- a/pain001/api/models.py
+++ b/pain001/api/models.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pydantic models for FastAPI request/response validation."""
 

--- a/pain001/api/ratelimit.py
+++ b/pain001/api/ratelimit.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """In-process, dependency-free rate limiting for the Pain001 REST API.
 

--- a/pain001/async_adapter.py
+++ b/pain001/async_adapter.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Async-ready wrappers around the synchronous library entry points."""
 

--- a/pain001/camt053/__init__.py
+++ b/pain001/camt053/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Camt.053 bank statement parsing and generation utilities."""
 

--- a/pain001/camt053/generator.py
+++ b/pain001/camt053/generator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Builder for ISO 20022 camt.053 bank-to-customer statements.
 

--- a/pain001/camt053/parser.py
+++ b/pain001/camt053/parser.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Parser for ISO 20022 camt.053 bank statements."""
 

--- a/pain001/cli/__init__.py
+++ b/pain001/cli/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Command-line interface package for pain001."""

--- a/pain001/cli/cli.py
+++ b/pain001/cli/cli.py
@@ -1,18 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-#
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Click-based command-line interface for generating ISO 20022 payment files."""
 

--- a/pain001/config/__init__.py
+++ b/pain001/config/__init__.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Configuration loading and profile resolution."""
 

--- a/pain001/config/manager.py
+++ b/pain001/config/manager.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Hierarchical configuration loader for CLI and library usage."""
 

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Shared constants and configuration for the pain001 library."""
 

--- a/pain001/context/__init__.py
+++ b/pain001/context/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Application context package for pain001."""

--- a/pain001/context/context.py
+++ b/pain001/context/context.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Singleton application context that owns the shared pain001 logger."""
 

--- a/pain001/core/__init__.py
+++ b/pain001/core/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Core processing package for pain001."""

--- a/pain001/core/core.py
+++ b/pain001/core/core.py
@@ -1,18 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-#
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """End-to-end orchestration of ISO 20022 payment file generation."""
 

--- a/pain001/csv/__init__.py
+++ b/pain001/csv/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """CSV operations module for pain001."""

--- a/pain001/csv/load_csv_data.py
+++ b/pain001/csv/load_csv_data.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Load payment data from CSV files."""
 

--- a/pain001/csv/validate_csv_data.py
+++ b/pain001/csv/validate_csv_data.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 # Validate the CSV data before processing it. The CSV data must contain
 # the following columns:

--- a/pain001/data/__init__.py
+++ b/pain001/data/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Data loading and validation module."""
 

--- a/pain001/data/loader.py
+++ b/pain001/data/loader.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Universal data loader supporting multiple input sources."""
 

--- a/pain001/db/__init__.py
+++ b/pain001/db/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Database operations module for pain001."""

--- a/pain001/db/load_db_data.py
+++ b/pain001/db/load_db_data.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 #
 # CodeQL: This module uses parameterized queries where possible.
 # For table names (which cannot be parameterized), we use strict allowlist validation

--- a/pain001/db/load_db_data_streaming.py
+++ b/pain001/db/load_db_data_streaming.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Memory-efficient streaming loader for SQLite database."""
 

--- a/pain001/db/validate_db_data.py
+++ b/pain001/db/validate_db_data.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Validate SQLite payment data against required-field rules."""
 

--- a/pain001/exceptions.py
+++ b/pain001/exceptions.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Custom exception hierarchy for Pain001.
 

--- a/pain001/json/__init__.py
+++ b/pain001/json/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """JSON data loaders for pain001."""
 

--- a/pain001/json/load_json_data.py
+++ b/pain001/json/load_json_data.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """JSON data loader for payment data."""
 

--- a/pain001/logging_schema/__init__.py
+++ b/pain001/logging_schema/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Standardized logging schema for Pain001.
 

--- a/pain001/logging_schema/_version.py
+++ b/pain001/logging_schema/_version.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Resolved package version, used as the ``version`` field in log records."""
 

--- a/pain001/logging_schema/context.py
+++ b/pain001/logging_schema/context.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Per-request ID propagation for distributed tracing."""
 

--- a/pain001/logging_schema/events.py
+++ b/pain001/logging_schema/events.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Structured event emitters that build flat, PII-redacted JSON log records."""
 

--- a/pain001/logging_schema/formatter.py
+++ b/pain001/logging_schema/formatter.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """JSON log formatter and handler configuration (Issue #149)."""
 

--- a/pain001/logging_schema/metrics.py
+++ b/pain001/logging_schema/metrics.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Detailed execution telemetry for API observability and tracing."""
 

--- a/pain001/logging_schema/redaction.py
+++ b/pain001/logging_schema/redaction.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """PII redaction and log-injection sanitization (GDPR/PCI-DSS, CWE-117)."""
 

--- a/pain001/logging_schema/schema.py
+++ b/pain001/logging_schema/schema.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Constant vocabularies for structured logging (levels, statuses, events,
 fields).

--- a/pain001/logging_schema/tracker.py
+++ b/pain001/logging_schema/tracker.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Execution summary tracking with automatic event counting."""
 

--- a/pain001/lsp/__init__.py
+++ b/pain001/lsp/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Language Server Protocol support for Pain001 payment CSV files.
 

--- a/pain001/lsp/diagnostics.py
+++ b/pain001/lsp/diagnostics.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pure diagnostic engine for Pain001 payment CSV documents.
 

--- a/pain001/lsp/server.py
+++ b/pain001/lsp/server.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Language Server (stdio) for Pain001 payment CSV files.
 

--- a/pain001/mcp/__init__.py
+++ b/pain001/mcp/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Model Context Protocol (MCP) server for Pain001.
 

--- a/pain001/mcp/server.py
+++ b/pain001/mcp/server.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pain001 MCP server (stdio transport).
 

--- a/pain001/migrate.py
+++ b/pain001/migrate.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """CLI for ISO 20022 version migration."""
 

--- a/pain001/migration/__init__.py
+++ b/pain001/migration/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Migration helpers for ISO 20022 version upgrades."""
 

--- a/pain001/migration/version_mapper.py
+++ b/pain001/migration/version_mapper.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment data version migration utilities."""
 

--- a/pain001/observability/__init__.py
+++ b/pain001/observability/__init__.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Observability surface for pain001: metric events + OpenTelemetry tracing.
 

--- a/pain001/observability/otel.py
+++ b/pain001/observability/otel.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """OpenTelemetry tracing surface for pain001 (opt-in, zero-cost when off).
 

--- a/pain001/pain002/__init__.py
+++ b/pain001/pain002/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pain.002 payment status report parsing and generation utilities."""
 

--- a/pain001/pain002/generator.py
+++ b/pain001/pain002/generator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Builder for ISO 20022 pain.002 payment status reports.
 

--- a/pain001/pain002/parser.py
+++ b/pain001/pain002/parser.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Parser for ISO 20022 pain.002 payment status reports."""
 

--- a/pain001/parquet/__init__.py
+++ b/pain001/parquet/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Parquet data loaders for pain001 (optional feature)."""
 

--- a/pain001/parquet/load_parquet_data.py
+++ b/pain001/parquet/load_parquet_data.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Parquet data loader for payment data (optional feature)."""
 

--- a/pain001/plugins/__init__.py
+++ b/pain001/plugins/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Public plugin contract for pain001 v0.0.54+.
 

--- a/pain001/plugins/_builtins.py
+++ b/pain001/plugins/_builtins.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Adapters that surface the existing loaders as plugin instances.
 

--- a/pain001/plugins/_version.py
+++ b/pain001/plugins/_version.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Single source of truth for the plugin-contract API version.
 

--- a/pain001/plugins/builtins_gpg.py
+++ b/pain001/plugins/builtins_gpg.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Built-in GPG-decrypting loader (requires the ``pain001[gpg]`` extra).
 

--- a/pain001/plugins/contracts.py
+++ b/pain001/plugins/contracts.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Protocol definitions for the pain001 plugin contract.
 

--- a/pain001/plugins/registry.py
+++ b/pain001/plugins/registry.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Process-level plugin registry + entry-point discovery.
 

--- a/pain001/schemas/__init__.py
+++ b/pain001/schemas/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Bundled JSON validation schemas for pain001 message types."""

--- a/pain001/security/__init__.py
+++ b/pain001/security/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Security utilities for Pain001."""
 

--- a/pain001/security/path_validator.py
+++ b/pain001/security/path_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Path validation and sanitization to prevent security vulnerabilities."""
 

--- a/pain001/templates/__init__.py
+++ b/pain001/templates/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates for pain001."""
 

--- a/pain001/templates/guardrails.py
+++ b/pain001/templates/guardrails.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Guardrails that detect template/schema drift."""
 

--- a/pain001/templates/pain.001.001.03/__init__.py
+++ b/pain001/templates/pain.001.001.03/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates."""

--- a/pain001/templates/pain.001.001.04/__init__.py
+++ b/pain001/templates/pain.001.001.04/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates."""

--- a/pain001/templates/pain.001.001.05/__init__.py
+++ b/pain001/templates/pain.001.001.05/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates."""

--- a/pain001/templates/pain.001.001.06/__init__.py
+++ b/pain001/templates/pain.001.001.06/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates."""

--- a/pain001/templates/pain.001.001.07/__init__.py
+++ b/pain001/templates/pain.001.001.07/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates."""

--- a/pain001/templates/pain.001.001.08/__init__.py
+++ b/pain001/templates/pain.001.001.08/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates."""

--- a/pain001/templates/pain.001.001.09/__init__.py
+++ b/pain001/templates/pain.001.001.09/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 payment initiation templates."""

--- a/pain001/templates/pain.001.001.10/__init__.py
+++ b/pain001/templates/pain.001.001.10/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """pain.001.001.10 template assets."""

--- a/pain001/templates/pain.001.001.11/__init__.py
+++ b/pain001/templates/pain.001.001.11/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """pain.001.001.11 template assets."""

--- a/pain001/templates/pain.001.001.12/__init__.py
+++ b/pain001/templates/pain.001.001.12/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """pain.001.001.12 template assets."""

--- a/pain001/templates/pain.001.001.13/__init__.py
+++ b/pain001/templates/pain.001.001.13/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """pain.001.001.12 template assets."""

--- a/pain001/templates/pain.008.001.02/__init__.py
+++ b/pain001/templates/pain.008.001.02/__init__.py
@@ -1,16 +1,15 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Bundled pain.008.001.02 template assets."""

--- a/pain001/templates/registry.py
+++ b/pain001/templates/registry.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Automatic discovery and metadata registry for bundled templates."""
 

--- a/pain001/test_fixtures/__init__.py
+++ b/pain001/test_fixtures/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Internal test fixtures for pain001."""

--- a/pain001/validation/__init__.py
+++ b/pain001/validation/__init__.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Validation module for Pain001.
 

--- a/pain001/validation/bic_validator.py
+++ b/pain001/validation/bic_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """BIC (Business Identifier Code) / SWIFT Code validator.
 

--- a/pain001/validation/charset.py
+++ b/pain001/validation/charset.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ISO 20022 restricted character-set validation and transliteration.
 

--- a/pain001/validation/iban_validator.py
+++ b/pain001/validation/iban_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """IBAN (International Bank Account Number) validator.
 

--- a/pain001/validation/schema_validator.py
+++ b/pain001/validation/schema_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """JSON Schema-based validator for payment data.
 

--- a/pain001/validation/schemes.py
+++ b/pain001/validation/schemes.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Payment-scheme rulebook validation, layered on top of XSD validation.
 

--- a/pain001/validation/service.py
+++ b/pain001/validation/service.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """ValidationService: Centralized validation orchestrator for Pain001.
 

--- a/pain001/xml/__init__.py
+++ b/pain001/xml/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """XML generation and validation package for pain001."""

--- a/pain001/xml/create_root_element.py
+++ b/pain001/xml/create_root_element.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 # pylint: disable=C0301
 

--- a/pain001/xml/create_xml_element.py
+++ b/pain001/xml/create_xml_element.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Helper for creating XML child elements."""
 

--- a/pain001/xml/generate_updated_xml_file_path.py
+++ b/pain001/xml/generate_updated_xml_file_path.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 # Standard library imports
 

--- a/pain001/xml/generate_xml.py
+++ b/pain001/xml/generate_xml.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 # pylint: disable=duplicate-code
 

--- a/pain001/xml/message_registry.py
+++ b/pain001/xml/message_registry.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Registry-driven XML message preparation pipeline."""
 

--- a/pain001/xml/register_namespaces.py
+++ b/pain001/xml/register_namespaces.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Register ISO 20022 XML namespaces for ElementTree serialization."""
 

--- a/pain001/xml/validate_via_xsd.py
+++ b/pain001/xml/validate_via_xsd.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Validate XML documents against XSD schemas."""
 
 import logging
@@ -15,22 +21,6 @@ logger = logging.getLogger(__name__)
 def _get_cached_schema(xsd_file_path: str) -> xmlschema.XMLSchema:
     """Return a cached XMLSchema instance for the given XSD file path."""
     return xmlschema.XMLSchema(xsd_file_path)
-
-
-# Copyright (C) 2023-2026 Pain001. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 
 def validate_via_xsd(xml_file_path: str, xsd_file_path: str) -> bool:

--- a/pain001/xml/write_xml_to_file.py
+++ b/pain001/xml/write_xml_to_file.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """
 This module contains a utility function for writing XML content to a file.

--- a/pain001/xml/xml_to_string.py
+++ b/pain001/xml/xml_to_string.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """
 This module provides utilities for converting XML ElementTree objects to strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,35 @@
-[tool.poetry]
+# PEP 639 licence expression. Poetry maps a legacy `license = "..."`
+# string to a single classifier and falls back to
+# "License :: Other/Proprietary License" for a compound expression —
+# actively misleading on an open-source project. Declaring it here
+# emits `License-Expression: Apache-2.0 OR MIT` with no classifier.
+[project]
 name = "pain001"
+license = "Apache-2.0 OR MIT"
+license-files = ["LICENSE", "LICENSE-APACHE", "LICENSE-MIT"]
+# Everything else still comes from [tool.poetry] below; declaring it
+# dynamic keeps Poetry authoritative for those fields.
+dynamic = [
+    # [tool.poetry].version stays the single source of truth, so
+    # scripts/preflight_release.py and the version-sync CI check keep
+    # matching exactly one `version = "..."` line.
+    "version",
+    "dependencies",
+    "optional-dependencies",
+    "requires-python",
+    "readme",
+    "description",
+    "authors",
+    "keywords",
+    "classifiers",
+    "urls",
+    "scripts",
+]
+
+[tool.poetry]
 version = "0.0.59"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
-license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/sebastienrousseau/pain001"
 homepage = "https://pain001.com"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+

--- a/tests/perf_benchmarks.py
+++ b/tests/perf_benchmarks.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Performance benchmarks for pain001 library."""
 

--- a/tests/test_additional_coverage.py
+++ b/tests/test_additional_coverage.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for additional module coverage."""
 

--- a/tests/test_additional_message_types.py
+++ b/tests/test_additional_message_types.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Pain001 FastAPI simplified tests."""
 

--- a/tests/test_api_metrics.py
+++ b/tests/test_api_metrics.py
@@ -1,15 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the Prometheus metrics registry, middleware, and endpoint."""
 

--- a/tests/test_api_portal.py
+++ b/tests/test_api_portal.py
@@ -1,15 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the REST API portal: versioning, rate limiting, persistence."""
 

--- a/tests/test_async_adapter.py
+++ b/tests/test_async_adapter.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for the asyncio adapter wrappers."""
 

--- a/tests/test_async_adapters.py
+++ b/tests/test_async_adapters.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 import asyncio
 from unittest.mock import patch
 

--- a/tests/test_backward_compatibility.py
+++ b/tests/test_backward_compatibility.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Backward compatibility tests for pain001 refactoring.
 

--- a/tests/test_bic_validator.py
+++ b/tests/test_bic_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for pain001.validation.bic_validator module."""
 

--- a/tests/test_camt053_generator.py
+++ b/tests/test_camt053_generator.py
@@ -1,15 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the camt.053 statement generator (and round-trip)."""
 

--- a/tests/test_charset.py
+++ b/tests/test_charset.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for the ISO 20022 character-set guard."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 import os
 import tempfile

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Additional CLI tests for coverage."""
 

--- a/tests/test_cli_error_paths.py
+++ b/tests/test_cli_error_paths.py
@@ -1,18 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-#
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Test coverage gaps - CLI error paths and edge cases."""
 

--- a/tests/test_cli_library_parity.py
+++ b/tests/test_cli_library_parity.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 from pathlib import Path
 
 from click.testing import CliRunner

--- a/tests/test_cli_schemes.py
+++ b/tests/test_cli_schemes.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """End-to-end CLI tests for the --scheme rulebook flags."""
 

--- a/tests/test_cli_subcommands.py
+++ b/tests/test_cli_subcommands.py
@@ -1,15 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the Pain001 CLI subcommand suite and backwards-compat routing."""
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 import pytest
 
 from pain001.config import ConfigManager

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Tests for conftest pytest plugin."""
 
 from conftest import SLOMonitor, SLOPlugin, pytest_addoption

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import logging

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import os

--- a/tests/test_coverage_closers_v053.py
+++ b/tests/test_coverage_closers_v053.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Targeted coverage-closer tests for v0.0.53 (line + branch -> 100%).
 

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Targeted error-path tests that complete branch coverage.
 

--- a/tests/test_csv_datetime_validation.py
+++ b/tests/test_csv_datetime_validation.py
@@ -1,18 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-#
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Test coverage gaps to achieve 99%+ coverage."""
 

--- a/tests/test_csv_loader.py
+++ b/tests/test_csv_loader.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import csv

--- a/tests/test_csv_validator.py
+++ b/tests/test_csv_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import unittest

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import csv

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for the unified data loader."""
 

--- a/tests/test_data_loader_streaming.py
+++ b/tests/test_data_loader_streaming.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for data loader streaming functionality."""
 

--- a/tests/test_data_source_errors.py
+++ b/tests/test_data_source_errors.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Error-path tests for the data loaders and validators."""
 

--- a/tests/test_db_loader.py
+++ b/tests/test_db_loader.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import sqlite3

--- a/tests/test_db_validator.py
+++ b/tests/test_db_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import unittest

--- a/tests/test_docker_smoke.py
+++ b/tests/test_docker_smoke.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Smoke tests for the bundled Dockerfile (issue #169).
 

--- a/tests/test_edge_branches.py
+++ b/tests/test_edge_branches.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Edge-branch regression tests for CLI and core helpers."""
 
 import xml.etree.ElementTree as et  # nosec B405 - only used for element creation in tests, not parsing

--- a/tests/test_error_paths.py
+++ b/tests/test_error_paths.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Edge-case and error-path tests for core, CLI, and XSD validation."""
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Run every script in examples/ and require a zero exit code.
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for pain001.exceptions module."""
 

--- a/tests/test_financial_properties.py
+++ b/tests/test_financial_properties.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Property-based tests for financial amount handling.
 

--- a/tests/test_golden_files.py
+++ b/tests/test_golden_files.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Golden-file regression tests: byte-exact XML output per message version.
 
 Regenerate fixtures after an intentional output change with:

--- a/tests/test_hypothesis_properties.py
+++ b/tests/test_hypothesis_properties.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 from hypothesis import given
 from hypothesis import strategies as st
 

--- a/tests/test_iban_validator.py
+++ b/tests/test_iban_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for pain001.validation.iban_validator module."""
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Comprehensive tests for all ISO 20022 versions with multiple input methods.
 

--- a/tests/test_integration_matrix.py
+++ b/tests/test_integration_matrix.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Comprehensive 4×9 integration test matrix for all ISO 20022 versions.
 

--- a/tests/test_json_loader.py
+++ b/tests/test_json_loader.py
@@ -1,18 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-#
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """
 Comprehensive tests for JSON and JSONL data loaders.

--- a/tests/test_json_logging.py
+++ b/tests/test_json_logging.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for JSON logging configuration and telemetry (Issue #149)."""
 

--- a/tests/test_llm_ergonomics.py
+++ b/tests/test_llm_ergonomics.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """LLM-ergonomic generate-path regression tests (v0.0.54).
 

--- a/tests/test_logging_schema.py
+++ b/tests/test_logging_schema.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for structured logging schema."""
 

--- a/tests/test_lsp.py
+++ b/tests/test_lsp.py
@@ -1,15 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the Pain001 LSP diagnostics engine and pygls wiring."""
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 from click.testing import CliRunner
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for the Pain001 MCP server tools, resources, and prompt."""
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 import sys
 import types
 

--- a/tests/test_observability_otel.py
+++ b/tests/test_observability_otel.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the OpenTelemetry tracing surface (v0.0.54 issue #4).
 

--- a/tests/test_openapi_sdk.py
+++ b/tests/test_openapi_sdk.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the typed OpenAPI client SDK (issue #170).
 

--- a/tests/test_pain001_versions.py
+++ b/tests/test_pain001_versions.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Parametrized template/schema asset tests for all pain.001 versions.
 

--- a/tests/test_pain002_generator.py
+++ b/tests/test_pain002_generator.py
@@ -1,15 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the pain.002 status-report generator (and round-trip)."""
 

--- a/tests/test_pain002_schema_validation.py
+++ b/tests/test_pain002_schema_validation.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Bundled-schema validation for pain.002 bank responses.
 
 The parser is namespace-agnostic by design — a bank may answer in any

--- a/tests/test_parquet_loader.py
+++ b/tests/test_parquet_loader.py
@@ -1,18 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-#
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """
 Comprehensive tests for Parquet data loader.

--- a/tests/test_path_validator.py
+++ b/tests/test_path_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Unit tests for the path_validator module."""
 

--- a/tests/test_plugins_cli.py
+++ b/tests/test_plugins_cli.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the `pain001 plugins` CLI subcommand group (v0.0.54 #1)."""
 

--- a/tests/test_plugins_contract.py
+++ b/tests/test_plugins_contract.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Regression tests for the pain001 plugin contract (issue v0.0.54 #1).
 

--- a/tests/test_plugins_coverage.py
+++ b/tests/test_plugins_coverage.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Coverage closers for `pain001.plugins._builtins` and `.registry`.
 

--- a/tests/test_plugins_gpg.py
+++ b/tests/test_plugins_gpg.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the GPG-decrypting built-in loader (v0.0.54 issue #3).
 

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Test cases for README.md code examples.
 

--- a/tests/test_redis_job_store.py
+++ b/tests/test_redis_job_store.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the Redis-backed job store (issue #171).
 

--- a/tests/test_redis_rate_limiter.py
+++ b/tests/test_redis_rate_limiter.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the Redis-backed distributed rate limiter (issue #172).
 

--- a/tests/test_regression_suite.py
+++ b/tests/test_regression_suite.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Feature-matrix regression suite.
 

--- a/tests/test_safety_migration.py
+++ b/tests/test_safety_migration.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Regression tests guarding the dependency-vulnerability gate migration (issue #175).
 

--- a/tests/test_sample_data_valid.py
+++ b/tests/test_sample_data_valid.py
@@ -1,15 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Guard: every bundled sample CSV must pass the library's own validators.
 

--- a/tests/test_scalar_reference.py
+++ b/tests/test_scalar_reference.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Regression tests for the hosted Scalar API reference (issue #174).
 

--- a/tests/test_schema_completeness.py
+++ b/tests/test_schema_completeness.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Every shipped XSD must be a real ISO schema, not a permissive stub.
 
 ``pain.001.001.12`` shipped a 475-byte placeholder whose body was a

--- a/tests/test_schema_guardrails.py
+++ b/tests/test_schema_guardrails.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 """Tests for SchemaValidator module."""
 
 import unittest

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for scheme-rulebook validation (SEPA Credit Transfer)."""
 

--- a/tests/test_sepa_b2b_profile.py
+++ b/tests/test_sepa_b2b_profile.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
 
 """Tests for the SEPA Business-to-Business Direct Debit profile (issue #173).
 

--- a/tests/test_streaming_loaders.py
+++ b/tests/test_streaming_loaders.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for streaming data loader functionality (Issue #122)."""
 

--- a/tests/test_streaming_pipeline.py
+++ b/tests/test_streaming_pipeline.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 from pathlib import Path
 
 from pain001.core.core import process_files_streaming

--- a/tests/test_template_registry.py
+++ b/tests/test_template_registry.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 from pain001.templates import DEFAULT_TEMPLATE_REGISTRY
 
 

--- a/tests/test_template_security.py
+++ b/tests/test_template_security.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_typing_and_validator_properties.py
+++ b/tests/test_typing_and_validator_properties.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Regression tests for the PEP 561 ``py.typed`` marker and property tests
 asserting the in-memory and on-disk XSD validators agree.

--- a/tests/test_validation_service.py
+++ b/tests/test_validation_service.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 # pylint: disable=redefined-outer-name
 # ^ Pytest fixtures intentionally redefine names - this is standard practice

--- a/tests/test_version_mapper.py
+++ b/tests/test_version_mapper.py
@@ -1,3 +1,9 @@
+# Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. See LICENSE-APACHE and LICENSE-MIT.
+
 import json
 import sqlite3
 from pathlib import Path

--- a/tests/test_xml_element.py
+++ b/tests/test_xml_element.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import unittest

--- a/tests/test_xml_file_path.py
+++ b/tests/test_xml_file_path.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 from pain001.xml.generate_updated_xml_file_path import (

--- a/tests/test_xml_generation.py
+++ b/tests/test_xml_generation.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for the live XML generation path (generate_xml)."""
 

--- a/tests/test_xml_generator.py
+++ b/tests/test_xml_generator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import unittest

--- a/tests/test_xml_namespaces.py
+++ b/tests/test_xml_namespaces.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Tests for the register_namespaces module."""
 

--- a/tests/test_xml_root_element.py
+++ b/tests/test_xml_root_element.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import xml.etree.ElementTree as et  # nosec B405 - only used for element creation in tests, not parsing

--- a/tests/test_xml_string_generation.py
+++ b/tests/test_xml_string_generation.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """
 Unit tests for XML string generation functionality.

--- a/tests/test_xml_to_string.py
+++ b/tests/test_xml_to_string.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# distributed under the Licences is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """
 Unit tests for pain001.xml.xml_to_string module.

--- a/tests/test_xml_versions.py
+++ b/tests/test_xml_versions.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 """Comprehensive tests for generate_xml covering all pain message versions."""
 

--- a/tests/test_xml_writer.py
+++ b/tests/test_xml_writer.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 import os
 import tempfile

--- a/tests/test_xsd_validator.py
+++ b/tests/test_xsd_validator.py
@@ -1,17 +1,16 @@
 # Copyright (C) 2023-2026 Pain001. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 OR MIT
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
+# Licensed under either of the Apache License, Version 2.0 or the MIT
+# License, at your option. You may not use this file except in
+# compliance with one of those licences. Copies are provided in
+# LICENSE-APACHE and LICENSE-MIT.
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the Licences is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# implied. See the applicable Licence for the specific language
+# governing permissions and limitations.
 
 
 import os


### PR DESCRIPTION
`LICENSE`, `LICENSE-APACHE`, `LICENSE-MIT` and the website footer all say **Apache-2.0 OR MIT**. Nothing a machine or a lawyer reads agreed:

| Source | Said |
|---|---|
| PyPI metadata (0.0.59) | `Apache-2.0` |
| `pyproject.toml` | `license = "Apache-2.0"` |
| 167 source headers | "Licensed under the Apache License, Version 2.0" |
| 27 source files | no header at all |

A downstream user choosing MIT had no supporting evidence in the artefact they installed.

## Source files — 194/194

- `SPDX-License-Identifier: Apache-2.0 OR MIT` on every Python file
- Header prose states the choice rather than Apache alone
- The 27 bare files now have a header, inserted after any shebang/encoding line
- One file carried the boilerplate twice; the stale copy is removed

## Package metadata

Declared via **PEP 639** in `[project]` as a licence *expression*:

```
License-Expression: Apache-2.0 OR MIT
License-File: LICENSE / LICENSE-APACHE / LICENSE-MIT
```

**Not** done as a legacy `license = "..."` string — I tried that first and the built wheel came out with `Classifier: License :: Other/Proprietary License`, because Poetry falls back to that for any compound expression. On an OSS project that's worse than the understatement it replaces.

`[tool.poetry].version` stays the single source of truth (`version` is declared dynamic), so `preflight_release.py` and the `version-sync` check still match exactly one `version = "..."` line — otherwise the next release bump would have needed two edits.

## Verified

`poetry check` clean · 1468 tests pass · lint and the 100% coverage gate pass · the built wheel installs and `pain001 --version` runs · `importlib.metadata` on the installed package reports the expression with no licence classifiers.

Also clears gold's `license_per_file` and `copyright_per_file`.