### PR TITLE
Release v0.0.60 (in preparation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — 0.0.60
+
+A **licensing correctness and governance** release. No runtime behaviour
+change and no public API change so far. Add entries here as work lands.
+
+### Fixed
+
+- **The published licence did not match the claimed one.** LICENSE,
+  LICENSE-APACHE, LICENSE-MIT and the website all said dual
+  Apache-2.0 OR MIT, but PyPI published `Apache-2.0`, `pyproject.toml`
+  declared a single licence, all 167 source headers said Apache alone,
+  and 27 files had no header. Now `SPDX-License-Identifier:
+  Apache-2.0 OR MIT` in all 194 Python files, and the wheel carries
+  `License-Expression: Apache-2.0 OR MIT` with all three licence files.
+  Declared via PEP 639, not the legacy `license = "..."` string, which
+  Poetry maps to `License :: Other/Proprietary License` for a compound
+  expression. The corrected metadata only reaches PyPI on release, so
+  0.0.59 and earlier still advertise Apache-2.0 only.
+
+### Added
+
+- **Developer Certificate of Origin required.** Every commit needs a
+  `Signed-off-by` trailer, enforced by `.github/workflows/dco.yml`;
+  see `DCO.txt` and `CONTRIBUTING.md`.
+- **Security assurance case** at `docs/assurance-case.md` — threat
+  model, trust boundaries, secure-design principles applied, and
+  countered implementation weaknesses, each with checkable evidence.
+
 ## [0.0.59] - 2026-07-30
 
 A **supply-chain** release. No runtime behaviour change and no public

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -16,7 +16,7 @@
 
 import logging
 
-__version__ = "0.0.59"
+__version__ = "0.0.60"
 
 # Library convention: emit nothing unless the host app configures
 # logging (PEP 282 / logging HOWTO).

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -21,7 +21,7 @@ from pathlib import Path
 BASE_DIR = Path(os.path.dirname(os.path.abspath(__file__))).resolve()
 
 # Shared metadata
-VERSION = "0.0.59"
+VERSION = "0.0.60"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 TEMPLATES_DIR = BASE_DIR / "templates"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = [
 ]
 
 [tool.poetry]
-version = "0.0.59"
+version = "0.0.60"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 readme = "README.md"

--- a/releases/v0.0.60.md
+++ b/releases/v0.0.60.md
@@ -1,0 +1,74 @@
+# Pain001 Release v0.0.60
+
+**Release Date:** _unreleased — in preparation_
+**Tag:** v0.0.60
+**Python:** 3.10+
+**Status:** in preparation
+
+> This note is being written as work lands. Add to the sections below as
+> further changes merge into `release/v0.0.60`.
+>
+> **At tag time, three edits are required** — `make release-check` fails
+> until all three are done, which is deliberate:
+>
+> 1. Set **Release Date** above to the real date and **Status** to `Stable`.
+> 2. In `CHANGELOG.md`, change `## [Unreleased] — 0.0.60` to
+>    `## [0.0.60] - YYYY-MM-DD`. The pre-flight matches that exact
+>    dated form and will not accept `[Unreleased]`.
+> 3. Merge this branch to `main` first. The pre-flight requires
+>    `on main` and `HEAD matches origin/main`, because a tag cut from a
+>    branch would ship unreviewed history.
+
+## Executive Summary
+
+A **licensing correctness and project-governance release**. No runtime
+behaviour change and no public API change so far — the software you
+install is identical. What changes is what the artefact *says about
+itself*, which until now did not match what the project claimed.
+
+## Fixed
+
+- **The published licence was wrong.** `LICENSE`, `LICENSE-APACHE`,
+  `LICENSE-MIT` and the website all stated dual Apache-2.0 OR MIT, but
+  nothing machine-readable agreed: PyPI published `Apache-2.0`,
+  `pyproject.toml` declared a single licence, all 167 source headers
+  said Apache alone, and 27 files carried no header at all. Anyone
+  choosing the MIT option had no supporting evidence in the artefact
+  they installed.
+
+  Now consistent: `SPDX-License-Identifier: Apache-2.0 OR MIT` in all
+  194 Python files, and the wheel carries
+  `License-Expression: Apache-2.0 OR MIT` with all three licence files
+  bundled.
+
+  Declared through PEP 639 rather than the legacy `license = "..."`
+  string, because Poetry maps a compound expression to
+  `License :: Other/Proprietary License` — on an open-source project,
+  worse than the understatement it replaced.
+
+  **This is the change that most warrants shipping.** The corrected
+  metadata does not reach PyPI until a release is published, so
+  0.0.59 and earlier still advertise Apache-2.0 only.
+
+## Added
+
+- **Developer Certificate of Origin.** Contributions now require a
+  `Signed-off-by` trailer, enforced in CI: a pull request fails if any
+  non-merge commit lacks one, naming each commit and printing the
+  rebase that fixes it. `DCO.txt` carries the certificate text,
+  `CONTRIBUTING.md` explains what is being certified, and a pull
+  request template includes the checklist.
+
+- **A security assurance case** (`docs/assurance-case.md`): threat
+  model, trust boundaries, the secure-design principles applied, and
+  the implementation weaknesses countered — each claim pointing at
+  code, a CI gate, or a published artefact so a reader can check it.
+  Section 6 lists the known limitations rather than omitting them.
+
+## Upgrading
+
+```bash
+pip install --upgrade pain001
+```
+
+No API changes, no configuration changes, nothing to regenerate.


### PR DESCRIPTION
**Draft — open for work.** Version bumped, CHANGELOG section and release note started, no tag. Merge further work into `release/v0.0.60` and add it to the note as it lands.

## Already covered

| Commit | Change |
|---|---|
| `1348ade` | dual licence made consistent everywhere |
| `a2df2b4` | DCO sign-off required and CI-enforced |
| `f6a5aa9` | security assurance case |

No runtime behaviour change and no public API change so far.

## Why this one is worth shipping

The corrected `License-Expression: Apache-2.0 OR MIT` **only reaches PyPI when a release is published**. Until then 0.0.59 and earlier advertise `Apache-2.0` alone, while `LICENSE` says dual — so the discrepancy we just fixed is still live for anyone installing from PyPI.

## Deliberately failing pre-flight

`make release-check` fails right now, by design:

```
✗ CHANGELOG.md has a dated [0.0.60] section — missing or undated
✗ working tree is clean
✗ on main
```

The CHANGELOG heading is `## [Unreleased] — 0.0.60` rather than a dated one, because writing a plausible-looking date in advance is how changelogs end up lying. The pre-flight matches only the dated form, so it fails until the date is set at the right moment. All three tag-time edits are listed at the top of `releases/v0.0.60.md`.

## Verified with the bump applied

1468 tests pass · lint and the 100% coverage gate pass · version identical across `pyproject.toml`, `__init__.py` and `constants.py`.