### PR TITLE
ci(dependabot): fix an invalid config key and group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
       - "automated"
     commit-message:
       prefix: "chore(deps):"
-      prefix-scope: "dependencies"
       include: "scope"
     allow:
       - dependency-type: "direct"
@@ -31,3 +30,7 @@ updates:
     labels:
       - "ci/cd"
       - "automated"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This repository's Dependabot config was **invalid**, and had been for as long as the key has been present:

```
The property '#/updates/0/commit-message' contains additional
properties ["prefix-scope"] outside of the schema when none are allowed
```

`prefix-scope` is not a Dependabot key. While the file fails to parse, **Dependabot does not update this repository at all** — so the absence of dependency pull requests here was not calm, it was broken. The adjacent `include: "scope"` is the real key and already does what `prefix-scope` was reaching for, so deleting the line is the entire fix.

Found while rolling out the change below. It is unrelated to it, and worth fixing on its own.

## Grouping github-actions updates

Ungrouped, Dependabot opens **one pull request per action**. For a multi-part action that is a broken build rather than a style preference — `github/codeql-action` requires every `codeql-action/*` step in a run to be the same version, so a split bump fails on both halves:

```
##[error]Loaded a configuration file for version '4.37.6', but running version '4.37.4'
```

`init` and `analyze` usually sit in the same workflow file, so neither pull request can pass alone and re-running never helps. Across the fleet the pattern held exactly: every repository **with** a `groups:` key had green CodeQL bumps; every repository **without** one had them split and failing.

Configuration only — one file, one commit, no workflow or dependency version changes.
