### PR TITLE
fix(docker): keep the test tmpdir out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,13 @@ __pycache__/
 dist/
 build/
 .pytest_cache/
+# conftest.py redirects TMPDIR and pytest's basetemp into <package>/tmp so
+# the suite never writes outside the tree. That directory is gitignored but
+# was still entering the build context, and the wheel build fails on it:
+#   ValueError: '.../pain001/tmp/pytest/...' is not in the subpath of '/build'
+# So `docker build` failed on any machine where the tests had been run,
+# while CI passed on a fresh checkout.
+pain001/tmp/
 .mypy_cache/
 htmlcov/
 coverage.xml


### PR DESCRIPTION
`docker build` fails on any machine where the test suite has been run:

  ValueError: '.../pain001/tmp/pytest/test_secure_tempfile_writes_an0'
              is not in the subpath of '/build'
  ERROR: Failed building wheel for pain001

`conftest.py` deliberately points `TMPDIR`, `TEMP`, `TMP`,
`tempfile.tempdir` and pytest's `basetemp` at `<package>/tmp` so the
suite never writes outside the tree. That directory is gitignored, so
`git status` stays clean and it is easy to miss — but `.dockerignore`
did not list it, so it entered the build context and the wheel build
tripped over the absolute paths inside it.

CI never saw this because it builds from a fresh checkout where the
directory does not exist yet. It reproduces locally every time, and
`tests/test_docker_smoke.py` fails with it — which is how it surfaced,
during release pre-flight for 0.0.60.

Adding the directory to `.dockerignore` rather than changing where the
tests write: keeping temp files inside the tree is the deliberate part,
and the build context is the thing that should not include them.

Verified with the stray directory still in place, so the fix is what is
being tested rather than a clean tree:

  docker build -t pain001-smoke:test .   DONE
  pytest tests/test_docker_smoke.py      10 passed


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)