### PR TITLE
refactor(suite): put the whole suite on one version line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **The suite runs on a single version line.** `pain001.suite` used to
+  split members in two: wrappers in lockstep with the core, loaders
+  versioned independently on the grounds that they implement the
+  published plugin contract rather than the core's internals.
+
+  That is a defensible design and it is not the one this project uses.
+  One number now describes the whole suite — `pain001`, `pain001-mcp`,
+  `pain001-lsp`, `pain001-loader-xlsx`, `pain001-loader-mt101` — so
+  there is never a compatibility table to consult. Versions advance in
+  `0.0.1` steps along the `0.0.x` line; `0.1.0` follows `0.0.999`.
+
+  `SuiteMember.lockstep` is gone, and `lockstep_members()` and
+  `plugin_members()` are replaced by a single `members()`. The absence
+  of a second accessor is the policy. `PAIN001_API_VERSION` still exists
+  and the registry still enforces it at load time — it is a safety net,
+  not the versioning rule.
+
+  `scripts/check_suite_consistency.py` now holds every member to the
+  same rule and reports `pain001-loader-xlsx` (0.0.54) and
+  `pain001-loader-mt101` (0.0.2) as drift, which they are under this
+  policy. The README's "independently versioned" claim is corrected.
+
 ## [0.0.60] - 2026-08-20
 
 A **licensing correctness, plugin-surface and governance** release.

--- a/README.md
+++ b/README.md
@@ -498,7 +498,14 @@ print(output_path)  # -> "pain.001.001.03.xml" — validated and on disk
 Pain001 ships **two interchangeable install paths** for both its MCP and
 LSP integrations: an *in-tree* implementation that comes with `pain001`
 itself (smaller feature set, no extra package), and a *standalone* PyPI
-package (richer surface, independently versioned).
+package (richer surface).
+
+Every package in the suite — `pain001`, `pain001-mcp`, `pain001-lsp`,
+`pain001-loader-xlsx`, `pain001-loader-mt101` — ships the **same version
+number**. If the core is at `0.0.60` then so is everything else, so
+there is never a compatibility table to consult. Versions advance in
+`0.0.1` steps along the `0.0.x` line; `0.1.0` follows `0.0.999`. See
+`pain001.suite`, which a daily job checks against PyPI.
 
 ### MCP server
 

--- a/pain001/suite.py
+++ b/pain001/suite.py
@@ -12,40 +12,41 @@
 # implied. See the applicable Licence for the specific language
 # governing permissions and limitations.
 
-"""What the pain001 suite is, and which parts move together.
+"""What the pain001 suite is, and how its versions move.
 
 Users install more than one package — `pain001`, `pain001-mcp`,
 `pain001-lsp`, a loader or two — and the failure they hit is a version
 they cannot reason about: is `pain001-loader-xlsx==0.0.54` supposed to
 work with `pain001==0.0.60`?
 
-Two different answers are correct, for two different kinds of package,
-and writing them down here is the point of this module.
+The suite answers that with a single rule: **every member ships the same
+version as the core.** One number describes the whole suite. If the core
+is at ``0.0.60`` then so is every wrapper and every loader, and a user
+reading two different numbers is reading a mistake rather than a
+deliberate difference they need to understand.
 
-**Lockstep members** (`pain001-mcp`, `pain001-lsp`) ship the same
-version as the core. They wrap the core's own surface, so a core
-release is a release for them; a user reading two different numbers is
-reading a mistake.
+Versions advance in ``0.0.1`` steps and stay on the ``0.0.x`` line;
+``0.1.0`` follows ``0.0.999``, not ``0.0.60``. A member that jumps off
+that line is not signalling independence, it is breaking the one
+property this module exists to guarantee.
 
-**Plugins** (`pain001-loader-xlsx`, `pain001-loader-mt101`) version
-independently. They implement the published plugin contract, not the
-core's internals, and a loader bugfix should not wait for a core
-release. What binds them is not a matching version number but the
-contract generation in :data:`~pain001.plugins.PAIN001_API_VERSION`,
-which the registry enforces at load time — a plugin ahead of the host
-raises rather than misbehaving.
+An earlier revision of this module split the suite in two, versioning
+the loaders independently on the grounds that they implement the
+published plugin contract rather than the core's internals, so a loader
+fix need not wait for a core release. That is a defensible design and it
+is not the one this project uses: the cost of a user having to know
+which packages track the core and which do not outweighs the cost of an
+occasional no-change release. The contract generation in
+:data:`~pain001.plugins.PAIN001_API_VERSION` still exists and the
+registry still enforces it at load time — it is a safety net, not the
+versioning policy.
 
 Two rules follow, and both are checked by
 ``scripts/check_suite_consistency.py``:
 
-1. A lockstep member's published version must equal the core's.
-2. Any member's declared ``pain001`` floor must be a version that
+1. Every member's published version must equal the core's.
+2. Every member's declared ``pain001`` floor must be a version that
    actually exists, or the combination is uninstallable.
-
-A plugin's own version is deliberately not compared against the core's.
-``pain001-loader-mt101`` is at ``0.0.2`` and requires
-``pain001>=0.0.55``; that is correct independent versioning, not drift,
-and a check that flags it is measuring the wrong thing.
 """
 
 from __future__ import annotations
@@ -60,13 +61,11 @@ class SuiteMember(NamedTuple):
     Attributes:
         distribution: The name on PyPI.
         repository: The GitHub repository, ``owner/name``.
-        lockstep: Whether its version must equal the core's.
         summary: One line, for the README table and error messages.
     """
 
     distribution: str
     repository: str
-    lockstep: bool
     summary: str
 
 
@@ -84,31 +83,26 @@ SUITE: Final[MappingProxyType[str, SuiteMember]] = MappingProxyType(
             SuiteMember(
                 distribution="pain001",
                 repository="sebastienrousseau/pain001",
-                lockstep=True,
                 summary="Core library and CLI.",
             ),
             SuiteMember(
                 distribution="pain001-mcp",
                 repository="sebastienrousseau/pain001-mcp",
-                lockstep=True,
                 summary="Model Context Protocol server.",
             ),
             SuiteMember(
                 distribution="pain001-lsp",
                 repository="sebastienrousseau/pain001-lsp",
-                lockstep=True,
                 summary="Language server for payment data files.",
             ),
             SuiteMember(
                 distribution="pain001-loader-xlsx",
                 repository="sebastienrousseau/pain001-loader-xlsx",
-                lockstep=False,
                 summary="Excel (.xlsx/.xlsm) loader plugin.",
             ),
             SuiteMember(
                 distribution="pain001-loader-mt101",
                 repository="sebastienrousseau/pain001-loader-mt101",
-                lockstep=False,
                 summary="SWIFT MT101 loader plugin.",
             ),
         )
@@ -116,27 +110,17 @@ SUITE: Final[MappingProxyType[str, SuiteMember]] = MappingProxyType(
 )
 
 
-def lockstep_members() -> tuple[SuiteMember, ...]:
-    """Return the members whose version must equal the core's.
+def members() -> tuple[SuiteMember, ...]:
+    """Return every member of the suite, core first.
+
+    Every member is lockstep, so there is no second accessor to pick a
+    subset — the absence of one is the policy.
 
     Returns:
-        The lockstep members, core first.
+        All suite members, core first.
 
     Example:
-        >>> [m.distribution for m in lockstep_members()][0]
+        >>> [m.distribution for m in members()][0]
         'pain001'
     """
-    return tuple(m for m in SUITE.values() if m.lockstep)
-
-
-def plugin_members() -> tuple[SuiteMember, ...]:
-    """Return the members that version independently.
-
-    Returns:
-        The plugin members.
-
-    Example:
-        >>> all(not m.lockstep for m in plugin_members())
-        True
-    """
-    return tuple(m for m in SUITE.values() if not m.lockstep)
+    return tuple(SUITE.values())

--- a/scripts/check_suite_consistency.py
+++ b/scripts/check_suite_consistency.py
@@ -10,9 +10,9 @@ policy in :mod:`pain001.suite`?
 
 Two failures it catches, both of which have already happened:
 
-* A **lockstep member left behind.** `pain001-lsp` sat at 0.0.54 while
-  the core reached 0.0.59. Nothing broke, so nothing said anything.
-* A **plugin claiming a release it predates.** `pain001-loader-xlsx`
+* A **member left behind.** `pain001-lsp` sat at 0.0.54 while the core
+  reached 0.0.59. Nothing broke, so nothing said anything.
+* A **member claiming a release it predates.** `pain001-loader-xlsx`
   was published as 0.0.54 while requiring `pain001>=0.0.56`, so its own
   number described a suite version older than the core it demands.
 
@@ -157,24 +157,18 @@ def audit() -> tuple[list[str], dict[str, Any]]:
         floor = core_floor(info.get("requires_dist"))
         report["members"][member.distribution] = {
             "published": version,
-            "lockstep": member.lockstep,
             "core_floor": floor,
         }
 
-        if member.lockstep and version != core_version:
+        if version != core_version:
             problems.append(
-                f"{member.distribution} is {version}, but lockstep members "
-                f"must match the core ({core_version}). Release it, or "
-                f"move it out of lockstep in pain001/suite.py."
+                f"{member.distribution} is {version}, but every suite "
+                f"member must match the core ({core_version}). Release it."
             )
 
-        # A plugin's own version is deliberately *not* compared to the
-        # core's. Plugins number independently, so `0.0.2` requiring
-        # `pain001>=0.0.55` is correct, not drift — an earlier version
-        # of this check flagged exactly that and was wrong.
-        #
-        # What does matter is that the floor is reachable: a plugin
-        # requiring a core that was never published is uninstallable.
+        # The floor must also be reachable. A member requiring a core
+        # that was never published is uninstallable no matter how well
+        # its own version matches.
         if floor and _as_tuple(floor) > _as_tuple(core_version):
             problems.append(
                 f"{member.distribution} requires {CORE}>={floor}, but the "
@@ -211,10 +205,9 @@ def main(argv: list[str] | None = None) -> int:
     print(f"core: {CORE} {report['core']}")
     for name, data in sorted(report["members"].items()):
         published = data.get("published") or "unpublished"
-        kind = "lockstep" if data.get("lockstep") else "plugin"
         floor = data.get("core_floor")
-        suffix = f", needs {CORE}>={floor}" if floor else ""
-        print(f"  {name:<24} {published:<10} ({kind}{suffix})")
+        suffix = f"  (needs {CORE}>={floor})" if floor else ""
+        print(f"  {name:<24} {published:<10}{suffix}")
 
     if problems:
         print("\nSuite is inconsistent:", file=sys.stderr)

--- a/tests/test_suite_consistency.py
+++ b/tests/test_suite_consistency.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import pytest
 
-from pain001.suite import CORE, SUITE, lockstep_members, plugin_members
+from pain001.suite import CORE, SUITE, members
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
@@ -34,20 +34,25 @@ from check_suite_consistency import (  # noqa: E402
 class TestPolicy:
     """What the suite declares about itself."""
 
-    def test_core_is_a_lockstep_member(self) -> None:
-        """The core sets the number the others match."""
-        assert SUITE[CORE].lockstep is True
+    def test_core_is_the_first_member(self) -> None:
+        """The core sets the number every other member matches."""
+        assert members()[0].distribution == CORE
 
-    def test_every_member_is_split_into_exactly_one_group(self) -> None:
-        """A member is lockstep or a plugin, never both or neither."""
-        assert len(lockstep_members()) + len(plugin_members()) == len(SUITE)
+    def test_members_covers_the_whole_suite(self) -> None:
+        """There is no subset to pick: every member is lockstep."""
+        assert len(members()) == len(SUITE)
 
-    def test_wrappers_are_lockstep_and_loaders_are_not(self) -> None:
-        """The distinction is the whole point of the module."""
-        lockstep = {m.distribution for m in lockstep_members()}
-        plugins = {m.distribution for m in plugin_members()}
-        assert {"pain001-mcp", "pain001-lsp"} <= lockstep
-        assert {"pain001-loader-xlsx", "pain001-loader-mt101"} <= plugins
+    def test_the_loaders_are_members_like_any_other(self) -> None:
+        """The loaders are not a separate versioning tier.
+
+        An earlier revision split the suite in two and versioned the
+        loaders independently. This asserts the split is gone, because
+        its absence is the policy.
+        """
+        names = {m.distribution for m in members()}
+        assert {"pain001-mcp", "pain001-lsp"} <= names
+        assert {"pain001-loader-xlsx", "pain001-loader-mt101"} <= names
+        assert not hasattr(SUITE[CORE], "lockstep")
 
     def test_membership_table_is_read_only(self) -> None:
         """Reference data a check trusts must not be reshapable."""
@@ -140,15 +145,21 @@ class TestAudit:
     def test_a_consistent_suite_reports_no_problems(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Lockstep matched, floors reachable."""
+        """Every member on the core's number, floors reachable.
+
+        The loaders carry 0.0.60 here like everything else. Under the
+        previous two-tier policy this fixture had them at 0.1.0 and
+        0.0.2 and still expected no problems, which is exactly the state
+        the suite now refuses.
+        """
         _stub(
             monkeypatch,
             {
                 "pain001": _member("0.0.60"),
                 "pain001-mcp": _member("0.0.60", "0.0.55"),
                 "pain001-lsp": _member("0.0.60", "0.0.55"),
-                "pain001-loader-xlsx": _member("0.1.0", "0.0.56"),
-                "pain001-loader-mt101": _member("0.0.2", "0.0.55"),
+                "pain001-loader-xlsx": _member("0.0.60", "0.0.56"),
+                "pain001-loader-mt101": _member("0.0.60", "0.0.55"),
             },
         )
 
@@ -157,7 +168,7 @@ class TestAudit:
         assert problems == []
         assert report["core"] == "0.0.60"
 
-    def test_a_lockstep_member_left_behind_is_reported(
+    def test_a_member_left_behind_is_reported(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """The drift that actually happened: lsp stuck at 0.0.54."""
@@ -174,14 +185,15 @@ class TestAudit:
 
         assert any("pain001-lsp is 0.0.54" in p for p in problems)
 
-    def test_an_independently_versioned_plugin_is_not_drift(
+    def test_a_loader_behind_the_core_is_drift(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """mt101 at 0.0.2 needing pain001>=0.0.55 is correct.
+        """A loader is held to the same rule as a wrapper.
 
-        An earlier version of this check compared a plugin's own version
-        against the core floor and flagged this. It was measuring the
-        wrong thing.
+        This test previously asserted the opposite — that mt101 at 0.0.2
+        requiring pain001>=0.0.55 was correct independent versioning. The
+        suite now runs on a single version line, so the same input is
+        drift and must be reported.
         """
         _stub(
             monkeypatch,
@@ -193,7 +205,7 @@ class TestAudit:
 
         problems, _ = audit()
 
-        assert problems == []
+        assert any("pain001-loader-mt101 is 0.0.2" in p for p in problems)
 
     def test_an_unreachable_floor_is_reported(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
`pain001.suite` split members into two tiers: wrappers in lockstep with
the core, loaders versioned independently because they implement the
published plugin contract rather than the core's internals, so a loader
fix need not wait for a core release.

That reasoning is sound in the abstract and it is not the policy this
project wants. The cost it ignores is the one users actually pay:
having to know which packages track the core and which do not, and
what `pain001-loader-xlsx==0.1.0` means next to `pain001==0.0.60`. One
number for the whole suite removes the question. An occasional
no-change release is the cheaper side of that trade.

So: every member ships the core's version. Versions advance in 0.0.1
steps along the 0.0.x line — 0.1.0 follows 0.0.999, not 0.0.60.

  - `SuiteMember.lockstep` removed.
  - `lockstep_members()` and `plugin_members()` collapse into
    `members()`. There is deliberately no accessor for a subset; the
    absence of one is the policy.
  - The checker holds every member to the same rule.
  - README's "independently versioned" claim corrected.

`PAIN001_API_VERSION` is untouched. The registry still refuses a plugin
built against a newer contract than the host, which remains worth having
— it is a safety net, not the versioning rule.

Two tests now assert the opposite of what they used to, which is the
honest shape of this change rather than something to hide:

  - the "consistent suite" fixture had the loaders at 0.1.0 and 0.0.2
    and expected no problems; that is now precisely the state the suite
    refuses, so the fixture carries 0.0.60 throughout.
  - `test_an_independently_versioned_plugin_is_not_drift` asserted that
    mt101 at 0.0.2 requiring pain001>=0.0.55 was correct. It is now
    `test_a_loader_behind_the_core_is_drift` and asserts it is reported.

Run against the live index, the checker reports exactly the two members
that need releasing:

  pain001-loader-xlsx is 0.0.54, but every suite member must match
  the core (0.0.60). Release it.
  pain001-loader-mt101 is 0.0.2, but every suite member must match
  the core (0.0.60). Release it.

Core stays at 0.0.60; this lands unreleased so the suite converges on
0.0.60 rather than chasing a new number.

  pytest tests/test_suite_consistency.py   28 passed
  full suite                               1464 passed, coverage
                                           97.50% — identical to before
                                           (pyarrow/pandas skips)
  ruff check / format                      clean


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)