### PR TITLE
chore(release): pain001 0.0.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.61] - 2026-08-20
+
+A **performance** release. Two hot paths that were quietly quadratic or
+pure-Python now are not, and the suite moves to a single version line.
 
 ### Performance
 

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -16,7 +16,7 @@
 
 import logging
 
-__version__ = "0.0.60"
+__version__ = "0.0.61"
 
 # Library convention: emit nothing unless the host app configures
 # logging (PEP 282 / logging HOWTO).

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -21,7 +21,7 @@ from pathlib import Path
 BASE_DIR = Path(os.path.dirname(os.path.abspath(__file__))).resolve()
 
 # Shared metadata
-VERSION = "0.0.60"
+VERSION = "0.0.61"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 TEMPLATES_DIR = BASE_DIR / "templates"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = [
 ]
 
 [tool.poetry]
-version = "0.0.60"
+version = "0.0.61"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 readme = "README.md"

--- a/releases/v0.0.61.md
+++ b/releases/v0.0.61.md
@@ -1,0 +1,103 @@
+# Pain001 v0.0.61
+
+**Release Date:** 2026-08-20
+**Tag:** v0.0.61
+**Python:** 3.10+
+**Status:** Stable
+
+## Executive Summary
+
+A performance release. Two paths that dominated their workloads were
+measured, found to be doing avoidable work, and fixed. Neither changes
+any output: XML documents and diagnostics are byte-for-byte what they
+were.
+
+The suite also moves to a single version line — every package ships the
+same number, so `pain001-mcp 0.0.61` pairs with `pain001 0.0.61` and
+there is no compatibility table to consult.
+
+## XSD validation is ~46x faster with `lxml`
+
+Validation was **93%** of the cost of generating a document. For a
+1000-transaction batch, template rendering and data preparation take
+0.036s; validation took 0.465s. Generation time was really validation
+time, and `xmlschema` is a pure-Python XSD implementation.
+
+When `lxml` is installed, libxml2 now acts as an accept/reject gate:
+
+| | before | after |
+|---|---|---|
+| `generate_xml_string`, 1000 tx | 0.501s | **0.082s** (6.1x) |
+| of which XSD validation | 0.465s | 0.032s |
+| validation alone, 1.4 MiB document | 729ms | **15.7ms** (46x) |
+
+```bash
+pip install "pain001[fast]"     # opts into lxml
+```
+
+It is optional and auto-detected. Without it, the pure-Python validator
+runs exactly as before — correct, just slower.
+
+**It can only shortcut an accept.** If libxml2 rejects a document, the
+code falls through to `xmlschema`, whose verdict is final and whose
+messages the error path reports. Installing or removing `lxml` cannot
+turn a rejected document into an accepted one — the direction that
+matters for payment data. Verdicts were compared across 121 documents
+(one valid, 120 invalid in nine different ways) with no disagreement,
+and no case of libxml2 accepting what `xmlschema` rejected.
+
+**The parser is hardened by hand.** `defusedxml` deliberately does not
+cover `lxml`, so entity resolution, DTD loading, network access and
+huge-tree parsing are switched off explicitly. The test for this runs
+the XXE attack rather than inspecting parser flags, and was checked
+against a default parser, which does leak the file.
+
+## CSV diagnostics are no longer quadratic
+
+`pain001.lsp.diagnostics` computed each cell's character span by
+splitting the whole line and summing the lengths of every preceding
+cell — once per cell. A 20-column row did ~200 length operations instead
+of ~20, and the generator inside that `sum` ran 525,000 times for a
+500-row document. It was also eager: the span was computed before
+knowing whether there was anything to report, so a clean document — an
+editor's normal case, recomputed on every keystroke — paid the whole
+cost to produce nothing.
+
+| rows | before | after |
+|---|---|---|
+| 500 | 43.4ms | **7.6ms** (5.7x) |
+| 2000 | 102.0ms | **32.1ms** (3.2x) |
+
+Spans are unchanged, verified against the old implementation across 411
+lines at every column index with zero mismatches. Scaling is now linear
+(4.23x for 4x the rows); it used to read as *sublinear* only because the
+per-row quadratic swamped the row count.
+
+## Also in this release
+
+- **The performance benchmark job measures something.** It ran the wrong
+  file, discarded its own errors with `|| true`, and its XML benchmark
+  timed a `ValueError` being raised rather than XML being generated. The
+  guard is now 0.5s per 1000 transactions — the figure originally
+  advertised, which did not hold when it was first measured honestly,
+  and now does with ~5x headroom.
+- **A single version line for the suite.** `pain001.suite` no longer
+  splits members into lockstep wrappers and independently-versioned
+  plugins. `SuiteMember.lockstep` is gone and the two accessors collapse
+  into `members()`.
+
+## Compatibility
+
+No API changes and no output changes. `lxml` is optional; nothing
+changes if it is absent.
+
+`pain001.suite.lockstep_members()` and `plugin_members()` are removed in
+favour of `members()`, and `SuiteMember.lockstep` no longer exists. That
+module was introduced in 0.0.60 and describes the suite's own release
+policy; it is not part of the payment-generation API.
+
+## Verification
+
+- 1547 tests, 100% coverage, with and without `lxml`
+- Verdict equivalence across 121 documents
+- Span equivalence across 411 lines at every column index


### PR DESCRIPTION
Performance release — see `releases/v0.0.61.md`.

- XSD validation via libxml2 when `lxml` is present: `generate_xml_string` 0.501s → 0.082s for 1000 transactions (46x on validation alone). Optional, auto-detected, and can only shortcut an *accept*.
- CSV diagnostics no longer quadratic in column count: 500 rows 43.4ms → 7.6ms.
- Suite moves to a single version line; all five packages release as 0.0.61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)