### PR TITLE
ci: catch a stale poetry.lock before it costs a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,28 @@ permissions:
   contents: read
 
 jobs:
+  # 0. LOCKFILE (Fastest Fail - a stale lock breaks every later job)
+  #
+  # Every poetry job here already dies on a stale lock, but it dies
+  # inside an install log with a dozen jobs red at once and nothing
+  # saying which of them is the cause. This says it in one line, in
+  # seconds, before anything else runs.
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - uses: abatilo/actions-poetry@3765cf608f2d4a72178a9fc5b918668e542b89b1 # v4.0.0
+      - name: ❯ Verify poetry.lock Is Current
+        run: |
+          if ! poetry check --lock; then
+            echo "::error::poetry.lock is stale. Run 'poetry lock' and commit the result."
+            exit 1
+          fi
+          echo "✅ poetry.lock matches pyproject.toml."
+
   # 1. VERSION SYNC (Fastest Fail - 0s Setup)
   version-sync:
     runs-on: ubuntu-latest

--- a/scripts/preflight_release.py
+++ b/scripts/preflight_release.py
@@ -133,6 +133,17 @@ def main() -> int:
         m.group(1) if m else "missing or undated",
     )
 
+    # poetry.lock must match pyproject.toml. The publish job installs
+    # with poetry, so a stale lock fails the release — but only after the
+    # tag is pushed and public. Editing pyproject and re-locking are one
+    # action; this is the check that says so before it matters.
+    lock_ok = run("poetry", "check", "--lock").returncode == 0
+    check(
+        "poetry.lock matches pyproject.toml",
+        lock_ok,
+        "" if lock_ok else "run `poetry lock` and commit the result",
+    )
+
     # clean tree and correct branch — cutting from a dirty tree is how
     # unreviewed changes end up inside a signed tag
     dirty = run("git", "status", "--porcelain").stdout.strip()


### PR DESCRIPTION
Editing pyproject.toml and leaving poetry.lock behind broke work three
times in one sitting — twice here, once in pain001-mcp. Every poetry job
in this repo already dies on it, so it does get caught, but the way it
gets caught is a dozen red jobs at once, each with the real cause buried
in an install log:

  pyproject.toml changed significantly since poetry.lock was last
  generated. Run `poetry lock` to fix the lock file.

Two additions, at the two points where it is cheapest to notice.

`scripts/preflight_release.py` now checks it. This is the earliest
possible signal: preflight runs before the tag exists, so a stale lock
becomes a line of output rather than a failed publish on a tag that is
already public and has to be deleted and re-cut.

A `lockfile` job in ci.yml runs `poetry check --lock` ahead of
everything else. It is a few seconds, and it names the problem instead
of leaving it to be inferred from whichever job happened to install
first.

Neither is clever; the point is that the failure arrives with its own
diagnosis attached, at a moment when fixing it costs nothing.

Checked against both states rather than assumed:

  current lock                        preflight ✓, `poetry check --lock` exits 0
  dependency added, not re-locked     preflight ✗ "run `poetry lock` and
                                      commit the result", exits 1


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)