### PR TITLE
docs(changelog): open 0.0.62 for the suite follow-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — 0.0.62
+
+Suite-wide follow-through on two things 0.0.61 left explicitly
+unfinished. No change in the core itself yet; the work so far is in the
+satellites, and they release together with this version.
+
+### Performance
+
+- **The bundled JSON Schema is now cached in both wrappers.**
+  `pain001-lsp` and `pain001-mcp` each re-read and re-parsed it on every
+  call. In the LSP that is a disk read and a JSON parse per keystroke,
+  behind completion, hover and the missing-field check:
+
+  | call | before | after |
+  |---|---|---|
+  | `completion_items` | 0.0805ms | **0.0029ms** (28x) |
+  | `hover_text` | 0.0794ms | **0.0002ms** (478x) |
+  | `missing_required_fields` | 0.0816ms | **0.0004ms** (196x) |
+  | `get_required_fields` (mcp) | 0.0788ms | **0.0002ms** (475x) |
+  | `get_input_schema` (mcp) | 0.0736ms | **0.0001ms** (888x) |
+
+  None of this is user-visible — 0.08ms is imperceptible — so it is
+  waste removed rather than latency fixed. The mcp half also corrects a
+  judgement from 0.0.61, where I measured the schema load against
+  `generate_message` (0.2% of it) and concluded caching was not worth
+  it. That compared it to the wrong tool: the read-only tools do
+  essentially nothing else.
+
+### Added
+
+- **Benchmarks for the paths the 0.0.61 set missed**: LSP completion and
+  hover, MCP's read-only discovery tools, XLSX streaming throughput and
+  per-cell value normalisation, and MT101's block-4 wire format and
+  field-dense transactions.
+
+  Where the numbers are now sub-microsecond, the guard is a property
+  rather than a threshold — a wall-clock bound loose enough for shared
+  CI would not notice a cache being deleted, so the tests assert the
+  schema is not re-read across repeated calls instead.
+
+### Changed
+
+- **`pain001-lsp` now installs from its `poetry.lock` in CI.** 0.0.61
+  added `poetry check --lock` there after finding the lock silently
+  stale, but nothing installed from it — so the gate proved the lock
+  matched `pyproject.toml` and nothing about whether the pinned set
+  worked. A `locked` job now runs the suite against exactly what the
+  lock pins, alongside the existing jobs that install against the live
+  range.
+
+- **`pain001-loader-mt101` enforces `ruff format`**, which
+  `pain001-loader-xlsx` already did. Four files had drifted.
+
 ## [0.0.61] - 2026-08-20
 
 A **performance** release. Two hot paths that were quietly quadratic or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — 0.0.62
+## [0.0.62] - 2026-08-21
 
 Suite-wide follow-through on two things 0.0.61 left explicitly
 unfinished. No change in the core itself yet; the work so far is in the

--- a/pain001/__init__.py
+++ b/pain001/__init__.py
@@ -16,7 +16,7 @@
 
 import logging
 
-__version__ = "0.0.61"
+__version__ = "0.0.62"
 
 # Library convention: emit nothing unless the host app configures
 # logging (PEP 282 / logging HOWTO).

--- a/pain001/constants.py
+++ b/pain001/constants.py
@@ -21,7 +21,7 @@ from pathlib import Path
 BASE_DIR = Path(os.path.dirname(os.path.abspath(__file__))).resolve()
 
 # Shared metadata
-VERSION = "0.0.61"
+VERSION = "0.0.62"
 SCHEMAS_DIR = BASE_DIR / "schemas"
 TEMPLATES_DIR = BASE_DIR / "templates"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = [
 ]
 
 [tool.poetry]
-version = "0.0.61"
+version = "0.0.62"
 description = "Pain001 is a Python Library for Automating ISO 20022-Compliant Payment Files Using CSV Data."
 authors = ["Sebastien Rousseau <sebastian.rousseau@gmail.com>"]
 readme = "README.md"

--- a/releases/v0.0.62.md
+++ b/releases/v0.0.62.md
@@ -1,0 +1,95 @@
+# Pain001 v0.0.62
+
+**Release Date:** 2026-08-21
+**Tag:** v0.0.62
+**Python:** 3.10+
+**Status:** Stable
+
+## Executive Summary
+
+A follow-through release. 0.0.61 shipped with two items called out as
+deliberately unfinished, and this closes both. The core library itself
+is unchanged — no API change, no behaviour change — and releases with
+the suite because every member ships the same version.
+
+The work is in the wrappers and loaders, and one part of it corrects a
+judgement made in 0.0.61.
+
+## The bundled JSON Schema is cached in both wrappers
+
+`pain001-lsp` and `pain001-mcp` each re-read and re-parsed the bundled
+JSON Schema on every call. In the language server that is a disk read
+and a JSON parse *per keystroke*, sitting behind completion, hover and
+the missing-field check.
+
+| call | before | after |
+|---|---|---|
+| `completion_items` | 0.0805ms | **0.0029ms** (28x) |
+| `hover_text` | 0.0794ms | **0.0002ms** (478x) |
+| `missing_required_fields` | 0.0816ms | **0.0004ms** (196x) |
+| `get_required_fields` (mcp) | 0.0788ms | **0.0002ms** (475x) |
+| `get_input_schema` (mcp) | 0.0736ms | **0.0001ms** (888x) |
+
+None of this is user-visible. 0.08ms is imperceptible, so this is waste
+removed rather than latency fixed, and it is worth saying plainly.
+
+The schemas ship read-only inside the installed package, so re-reading
+them cannot pick up a change — only repeat work. `pain001`'s XSD loader
+has cached its compiled schema for the same reason for several releases.
+
+**This corrects a call made in 0.0.61.** The mcp schema load was left
+uncached then, on the grounds that it costs 0.18ms against ~92ms for a
+200-record `generate_message` — 0.2% of the work, not worth a
+cache-invalidation question. The arithmetic was right and the comparison
+was wrong: the read-only discovery tools do essentially nothing *but*
+load the schema, and a model exploring the server calls them repeatedly.
+`validate_identifier` and `list_message_types` never touch the schema
+and were unchanged by the cache, which is the control that makes the
+numbers above a real effect rather than a measurement artefact.
+
+## `pain001-lsp` now installs from its lockfile
+
+0.0.61 added `poetry check --lock` to that repo after finding the lock
+already silently stale. That check is necessary and not sufficient: it
+proves the lock matches `pyproject.toml` and says nothing about whether
+the pinned set works, because no job installed from it.
+
+A `locked` job now runs the suite against exactly what the lock pins.
+The two jobs answer different questions and both are worth having:
+
+    locked  - do the pinned versions still work?   (reproducibility)
+    test    - do the newest allowed versions work? (drift detection)
+
+## Benchmarks for the paths 0.0.61 missed
+
+The 0.0.61 benchmarks covered one path per satellite. This adds:
+
+- **LSP** — completion and hover, the per-keystroke paths.
+- **MCP** — the read-only discovery tools.
+- **XLSX** — streaming throughput (the existing guard covered memory
+  only) and per-cell value normalisation, ~19% of a load.
+- **MT101** — the block-4 wire format, which is the only thing that
+  exercises `_unwrap_block4`, and field-dense transactions, which is
+  where `_lookup` would show up if it went quadratic.
+
+Where the numbers are now sub-microsecond the guard is a **property**
+rather than a threshold: any wall-clock bound loose enough to survive a
+shared CI runner would not notice a cache being deleted, so the tests
+assert the schema is not re-read across repeated calls. Verified by
+defeating the cache and watching them fail.
+
+## Also
+
+- `pain001-loader-mt101` enforces `ruff format`, which
+  `pain001-loader-xlsx` already did. Four files had drifted out of
+  format with nothing configured to notice.
+
+## Compatibility
+
+No API change and no behaviour change in `pain001`. The wrapper caches
+are internal.
+
+## Verification
+
+- 1557 tests in the core, 100% coverage
+- All five packages green, all on 0.0.62


### PR DESCRIPTION
Records what the satellites are doing under this version, so the release
line has a home before the core itself changes.

0.0.61 shipped with two things called out as deliberately unfinished:
the satellites had only the benchmarks added in that session, and
pain001-lsp's poetry.lock was gated but nothing installed from it. Both
are addressed in the satellite feat/v0.0.62 branches; this is the entry
that ties them to a version.

The core has no functional change yet. Under the single-version-line
policy it still releases alongside the others when they do, and opening
the section now is what stops that being a surprise at tag time — the
0.0.60 cut had to be done retroactively for exactly this reason.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)