### PR TITLE
fix(deps): bump pip to 26.2.1 for PYSEC-2026-3721

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2788,14 +2788,14 @@ tests = ["pytest (>=9)", "typing-extensions (>=4.15)"]
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 description = "The PyPA recommended tool for installing Python packages."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab"},
-    {file = "pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605"},
+    {file = "pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e"},
+    {file = "pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f"},
 ]
 
 [[package]]


### PR DESCRIPTION
`pip-audit` fails the Vulnerability Scan gate:

```
Found 1 known vulnerability in 1 package
pip  26.1.2  PYSEC-2026-3721  26.2
```

`pip` is transitive here — pinned by `poetry.lock`, not declared in `pyproject.toml` — so nothing in the manifest changes. Three lines of lockfile.

## Why this matters beyond the CVE

This was blocking **every open Dependabot PR in the repository**. The scan runs on each of them and the finding is on `main`, so none could go green regardless of what they bumped.

`poetry run pip-audit` now reports `No known vulnerabilities found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)