### PR TITLE
ci: test on Python 3.13 and 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"] # ✅ Enterprise Matrix
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"] # ✅ Enterprise Matrix
     name: 🧬 Quality Gate (Py ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Additive change: **the declared floor is unchanged**, so nothing that installs today stops installing. 3.14 simply becomes a version this package is known to work on rather than one nobody has tried.

## Verified before the matrix entry, not after

This repository's own suite was run end to end on **Python 3.14.6** against `origin/main` before this change was written. The suite reported 1520 passed, 20 skipped. One example test (03_cli_workflows.py) trips the 5s pytest-timeout in this sandbox, but it does so on 3.12 as well -- and more slowly -- so it is environmental rather than a 3.14 regression. Docker smoke tests were excluded as they need a daemon.

Adding a matrix row without checking would just paint the build red and teach people to ignore it.

## Dependency feasibility

Nineteen of the twenty core dependencies across the suite install on 3.14. The one exception is `crewai`, which caps Python below 3.14 — it is an optional agent-adapter extra, and `iso20022-mcp` (the only repository that declares it) already carries the marker.

## What changed

- CI matrix extended to `3.13` and `3.14`, keeping each matrix's existing floor.
- Python classifiers extended to match, where the package declares them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EsFfsj4VQ1d61CySdAoQK
