### PR TITLE
docs: add the v0.0.65 release note

### DIFF
--- a/releases/v0.0.65.md
+++ b/releases/v0.0.65.md
@@ -1,0 +1,82 @@
+# pain001 v0.0.65
+
+No changes to generation behaviour: `process_files` and
+`process_files_streaming` behave exactly as they did in 0.0.62. This
+release adds a benchmark, aligns the suite on one version, and fixes two
+long-standing defects in this changelog.
+
+## Why the number moved
+
+The `pain001` suite ships **one version number across all five
+packages** by policy, and it had drifted to four: `pain001` 0.0.62,
+`pain001-lsp` 0.0.64, `pain001-mcp` 0.0.63, `pain001-loader-mt101`
+0.0.62, `pain001-loader-xlsx` 0.0.63.
+
+Nothing breaks when that happens, which is exactly why it went
+unnoticed: a member left a release behind still installs, still imports,
+and still passes its own tests. Only the index disagrees, and only if
+somebody goes and looks.
+
+All five now sit on **0.0.65**.
+
+## A benchmark for the choice that actually matters
+
+`benches/bench_generate.py` measures what separates `process_files` from
+`process_files_streaming` — which is peak memory, not speed.
+
+| payments | eager ms | stream ms | eager MB | stream MB | files |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 200 | 80.6 | 86.9 | 3.97 | 4.00 | 1 |
+| 1,000 | 511.8 | 443.3 | 18.86 | 10.35 | 2 |
+| 4,000 | 1789.8 | 1709.5 | **74.77** | **10.49** | 8 |
+
+From 200 to 4,000 payments the eager peak grew **18.8×**. The streaming
+peak grew 2.6× and then stopped: it is bounded by the chunk size, not by
+the batch. At 4,000 payments streaming uses **7.1× less** memory for
+essentially the same wall-clock.
+
+That matters because a payment batch's size is not chosen by whoever runs
+the job. A month-end supplier run or a payroll file is as large as the
+business was that month, and an exporter sized from a test fixture meets
+that difference in production.
+
+Time is close either way because XML rendering and XSD validation
+dominate both paths. **Streaming is a memory decision, not a speed one.**
+
+One stated limit: peak comes from `tracemalloc`, which sees Python-level
+allocations only. The XML and XSD layers allocate in C and are not
+counted, so read these as a floor and as a comparison between the two
+paths — not as a budget.
+
+### Replaces the old script
+
+`scripts/benchmark_large_batches.py` is removed. It measured the same two
+calls at a single fixed size of 2,000 rows and reported only wall-clock.
+One size cannot show that one memory curve is flat and the other is not,
+which is the entire finding.
+
+## Two changelog defects, both pre-existing
+
+The refreshed suite conformance gate caught them:
+
+- `0.0.45` was documented **twice**, once as an empty stub.
+- `0.0.46` was documented **twice**, as two separate entries carrying
+  *different real content* — the FastAPI REST API, and the granular
+  exception hierarchy.
+
+The stub is removed and the two `0.0.46` entries are merged under one
+heading. **No release note was lost**: the FastAPI section, the exception
+hierarchy and the dry-run mode entry are all still present, and the file
+is six lines shorter.
+
+## Also
+
+- `tests/test_suite_conformance.py` refreshed to the current canonical
+  copy. Its drift-check probe now matches the bare word `pypi` rather
+  than a hostname, which CodeQL had been reading as an incomplete URL
+  sanitisation.
+- `SECURITY.md`'s supported-version table follows the bump.
+
+## Upgrading
+
+Nothing to do. `pip install --upgrade pain001`.


### PR DESCRIPTION
The release workflow requires `releases/v<version>.md` and fails without it. That's exactly what happened to the `v0.0.65` tag — every other job passed and **📦 Publish Release** stopped at:

```
❌ Release notes missing: releases/v0.0.65.md
```

This adds the file so that workflow can be re-run against the existing tag. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015EsFfsj4VQ1d61CySdAoQK